### PR TITLE
Expand map and update visuals

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -131,16 +131,33 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     for y in range(game.map.height):
         row = []
         for x in range(game.map.width):
-            lbl = tk.Label(map_frame, width=4, height=2, relief="ridge", borderwidth=1)
+            lbl = tk.Label(
+                map_frame,
+                width=2,
+                height=1,
+                relief="ridge",
+                borderwidth=1,
+                highlightthickness=0,
+            )
             lbl.grid(row=y, column=x, padx=1, pady=1)
             row.append(lbl)
         map_labels.append(row)
 
     def update_map() -> None:
+        color_map = {"forest": "green", "plains": "yellowgreen"}
         for y, r in enumerate(map_labels):
             for x, lbl in enumerate(r):
-                color = "green" if (x, y) == (game.x, game.y) else "white"
-                lbl.configure(bg=color)
+                terrain = game.map.terrain_at(x, y)
+                color = color_map.get(terrain.name, "white")
+                if (x, y) == (game.x, game.y):
+                    lbl.configure(
+                        bg=color,
+                        highlightbackground="black",
+                        highlightcolor="black",
+                        highlightthickness=2,
+                    )
+                else:
+                    lbl.configure(bg=color, highlightthickness=0)
 
     # Bottom-right stats
     stats_frame = tk.Frame(main)

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -6,7 +6,7 @@ from .settings import Setting
 
 
 class Game:
-    def __init__(self, setting: Setting, dinosaur_name: str, width: int = 5, height: int = 5):
+    def __init__(self, setting: Setting, dinosaur_name: str, width: int = 20, height: int = 30):
         self.setting = setting
         dstats = setting.playable_dinos[dinosaur_name]
         self.player = DinosaurStats(dinosaur_name, hunger=0, **dstats)


### PR DESCRIPTION
## Summary
- enlarge default map to 20x30
- make map squares smaller for the bigger grid
- color map cells by biome and outline player square in black

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68408a5c69d0832e9e0e1a0feba432fd