### PR TITLE
Improve map UI and add tile reveal

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -127,37 +127,51 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     map_frame = tk.Frame(main)
     map_frame.grid(row=0, column=1, sticky="nsew", padx=10, pady=10)
 
-    map_labels = []
+    map_tiles = []
+    tile_size = 20
     for y in range(game.map.height):
         row = []
         for x in range(game.map.width):
-            lbl = tk.Label(
+            c = tk.Canvas(
                 map_frame,
-                width=2,
-                height=1,
-                relief="ridge",
-                borderwidth=1,
+                width=tile_size,
+                height=tile_size,
                 highlightthickness=0,
+                bd=0,
             )
-            lbl.grid(row=y, column=x, padx=1, pady=1)
-            row.append(lbl)
-        map_labels.append(row)
+            c.grid(row=y, column=x, padx=1, pady=1)
+            row.append(c)
+        map_tiles.append(row)
 
     def update_map() -> None:
-        color_map = {"forest": "green", "plains": "yellowgreen"}
-        for y, r in enumerate(map_labels):
-            for x, lbl in enumerate(r):
+        color_map = {
+            "forest": "green",
+            "plains": "yellowgreen",
+            "floodplain": "tan",
+        }
+        for y, r in enumerate(map_tiles):
+            for x, canvas in enumerate(r):
                 terrain = game.map.terrain_at(x, y)
-                color = color_map.get(terrain.name, "white")
+                revealed = game.map.is_revealed(x, y)
+                color = color_map.get(terrain.name, "white") if revealed else "gray"
+                canvas.delete("all")
+                canvas.create_rectangle(
+                    0,
+                    0,
+                    tile_size,
+                    tile_size,
+                    fill=color,
+                    outline="black",
+                )
                 if (x, y) == (game.x, game.y):
-                    lbl.configure(
-                        bg=color,
-                        highlightbackground="black",
-                        highlightcolor="black",
-                        highlightthickness=2,
+                    canvas.create_rectangle(
+                        2,
+                        2,
+                        tile_size - 2,
+                        tile_size - 2,
+                        outline="black",
+                        width=2,
                     )
-                else:
-                    lbl.configure(bg=color, highlightthickness=0)
 
     # Bottom-right stats
     stats_frame = tk.Frame(main)

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -6,13 +6,14 @@ from .settings import Setting
 
 
 class Game:
-    def __init__(self, setting: Setting, dinosaur_name: str, width: int = 20, height: int = 30):
+    def __init__(self, setting: Setting, dinosaur_name: str, width: int = 30, height: int = 20):
         self.setting = setting
         dstats = setting.playable_dinos[dinosaur_name]
         self.player = DinosaurStats(dinosaur_name, hunger=0, **dstats)
         self.map = Map(width, height, setting.terrains)
         self.x = width // 2
         self.y = height // 2
+        self.map.reveal(self.x, self.y)
 
     def hunt(self):
         terrain = self.map.terrain_at(self.x, self.y)
@@ -28,6 +29,7 @@ class Game:
         nx = max(0, min(self.map.width - 1, self.x + dx))
         ny = max(0, min(self.map.height - 1, self.y + dy))
         self.x, self.y = nx, ny
+        self.map.reveal(self.x, self.y)
 
     def turn(self, action: str) -> str:
         if action == "hunt":

--- a/dinosurvival/map.py
+++ b/dinosurvival/map.py
@@ -13,7 +13,17 @@ class Map:
         self.width = width
         self.height = height
         self.terrains = terrains
-        self.grid = [[random.choice(list(terrains.values())) for _ in range(width)] for _ in range(height)]
+        self.grid = [
+            [random.choice(list(terrains.values())) for _ in range(width)]
+            for _ in range(height)
+        ]
+        self.revealed = [[False for _ in range(width)] for _ in range(height)]
 
     def terrain_at(self, x: int, y: int) -> Terrain:
         return self.grid[y][x]
+
+    def reveal(self, x: int, y: int) -> None:
+        self.revealed[y][x] = True
+
+    def is_revealed(self, x: int, y: int) -> bool:
+        return self.revealed[y][x]


### PR DESCRIPTION
## Summary
- add reveal tracking to map
- swap map width/height defaults and reveal initial tile
- ensure moving reveals tiles
- draw map using canvases and show player outline inside square

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68408e0b1020832eb2503a5dc45edc08