### PR TITLE
Add new biomes with noise map

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple text-based dinosaur survival game inspired by the BBC "Big Al" game. Th
 ## Features
 
 - Turn based actions: move or hunt on each turn.
-- Random terrain that affects the type of prey encountered.
+- Random terrain including forests, plains, swamps, woodlands, badlands and lakes that affects the type of prey encountered.
 - Support for multiple settings such as the Morrison Formation or Hell Creek.
 
 ## Requirements

--- a/dino_game.py
+++ b/dino_game.py
@@ -148,6 +148,10 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
             "forest": "green",
             "plains": "yellowgreen",
             "floodplain": "tan",
+            "swamp": "olivedrab",
+            "woodlands": "palegreen",
+            "badlands": "yellow",
+            "lake": "blue",
         }
         for y, r in enumerate(map_tiles):
             for x, canvas in enumerate(r):

--- a/dinosurvival/map.py
+++ b/dinosurvival/map.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Tuple
+from typing import Dict, Tuple, List
 import random
 
 @dataclass
@@ -13,10 +13,16 @@ class Map:
         self.width = width
         self.height = height
         self.terrains = terrains
-        self.grid = [
-            [random.choice(list(terrains.values())) for _ in range(width)]
-            for _ in range(height)
-        ]
+        terrain_list = list(terrains.values())
+        noise = self._generate_noise(width, height)
+        self.grid = []
+        for y in range(height):
+            row: List[Terrain] = []
+            for x in range(width):
+                n = noise[y][x]
+                idx = min(int(n * len(terrain_list)), len(terrain_list) - 1)
+                row.append(terrain_list[idx])
+            self.grid.append(row)
         self.revealed = [[False for _ in range(width)] for _ in range(height)]
 
     def terrain_at(self, x: int, y: int) -> Terrain:
@@ -27,3 +33,37 @@ class Map:
 
     def is_revealed(self, x: int, y: int) -> bool:
         return self.revealed[y][x]
+
+    def _generate_noise(self, width: int, height: int, scale: int = 4) -> List[List[float]]:
+        """Create a simple value noise map for distributing biomes."""
+        coarse_w = width // scale + 1
+        coarse_h = height // scale + 1
+        coarse = [[random.random() for _ in range(coarse_w)] for _ in range(coarse_h)]
+
+        def lerp(a: float, b: float, t: float) -> float:
+            return a + (b - a) * t
+
+        noise = []
+        for y in range(height):
+            fy = y / (height - 1) * (coarse_h - 1)
+            y0 = int(fy)
+            y1 = min(y0 + 1, coarse_h - 1)
+            ty = fy - y0
+            row = []
+            for x in range(width):
+                fx = x / (width - 1) * (coarse_w - 1)
+                x0 = int(fx)
+                x1 = min(x0 + 1, coarse_w - 1)
+                tx = fx - x0
+
+                n00 = coarse[y0][x0]
+                n10 = coarse[y0][x1]
+                n01 = coarse[y1][x0]
+                n11 = coarse[y1][x1]
+
+                n0 = lerp(n00, n10, tx)
+                n1 = lerp(n01, n11, tx)
+                val = lerp(n0, n1, ty)
+                row.append(val)
+            noise.append(row)
+        return noise

--- a/dinosurvival/settings.py
+++ b/dinosurvival/settings.py
@@ -21,6 +21,10 @@ MORRISON = Setting(
     terrains={
         "plains": Terrain("plains", {"small_prey": 0.8, "large_prey": 0.2}),
         "forest": Terrain("forest", {"small_prey": 0.6, "large_prey": 0.4}),
+        "swamp": Terrain("swamp", {"small_prey": 0.7, "large_prey": 0.3}),
+        "woodlands": Terrain("woodlands", {"small_prey": 0.6, "large_prey": 0.4}),
+        "badlands": Terrain("badlands", {"small_prey": 0.3, "large_prey": 0.7}),
+        "lake": Terrain("lake", {"small_prey": 0.9, "large_prey": 0.1}),
     },
 )
 
@@ -33,5 +37,9 @@ HELL_CREEK = Setting(
     terrains={
         "floodplain": Terrain("floodplain", {"small_prey": 0.4, "large_prey": 0.6}),
         "forest": Terrain("forest", {"small_prey": 0.7, "large_prey": 0.3}),
+        "swamp": Terrain("swamp", {"small_prey": 0.7, "large_prey": 0.3}),
+        "woodlands": Terrain("woodlands", {"small_prey": 0.6, "large_prey": 0.4}),
+        "badlands": Terrain("badlands", {"small_prey": 0.3, "large_prey": 0.7}),
+        "lake": Terrain("lake", {"small_prey": 0.9, "large_prey": 0.1}),
     },
 )


### PR DESCRIPTION
## Summary
- add new biomes to settings and game colors
- generate map using a simple noise map for better biome distribution
- document new biomes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684092a30dd8832e9fd0c0206f44a0ac