### PR TITLE
Add encounter UI and map size change

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -1,5 +1,6 @@
 import tkinter as tk
-from dinosurvival.game import Game
+import random
+from dinosurvival.game import Game, DINO_STATS
 from dinosurvival.settings import MORRISON, HELL_CREEK
 
 SETTINGS = {
@@ -107,6 +108,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         update_biome()
         update_map()
         update_stats()
+        update_encounters()
         if "Game Over" in result:
             for b in move_buttons.values():
                 b.config(state="disabled")
@@ -123,6 +125,28 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     move_buttons["stay"].grid(row=1, column=1)
     move_buttons["east"].grid(row=1, column=2)
     move_buttons["south"].grid(row=2, column=1)
+
+    # Bottom-left encounter display
+    encounter_frame = tk.Frame(main)
+    encounter_frame.grid(row=1, column=0, sticky="nsew", padx=10, pady=10)
+    tk.Label(encounter_frame, text="Encounters", font=("Helvetica", 16)).pack()
+    encounter_list = tk.Frame(encounter_frame)
+    encounter_list.pack(fill="both", expand=True)
+
+    def update_encounters() -> None:
+        for w in encounter_list.winfo_children():
+            w.destroy()
+        terrain = game.map.terrain_at(game.x, game.y).name
+        for name, stats in DINO_STATS.items():
+            if name == dinosaur_name:
+                continue
+            chance = stats.get("encounter_chance", {}).get(terrain, 0)
+            if random.random() < chance:
+                row = tk.Frame(encounter_list)
+                row.pack(anchor="w", pady=2, fill="x")
+                info = f"{name}  F:{stats.get('adult_fierceness',0)} S:{stats.get('adult_speed',0)}"
+                tk.Label(row, text=info).pack(side="left")
+                tk.Button(row, text="Hunt", width=5).pack(side="right")
 
     # Top-right map
     map_frame = tk.Frame(main)
@@ -216,6 +240,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     update_biome()
     update_map()
     update_stats()
+    update_encounters()
 
     root.mainloop()
 

--- a/dinosurvival/dino_stats.yaml
+++ b/dinosurvival/dino_stats.yaml
@@ -11,7 +11,16 @@
     "hatchling_energy_drain": 1.0,
     "adult_energy_drain": 2.5,
     "walking_energy_drain_multiplier": 1.2,
-    "carcass_food_value_modifier": 0.7
+    "carcass_food_value_modifier": 0.7,
+    "encounter_chance": {
+      "plains": 0.05,
+      "forest": 0.04,
+      "swamp": 0.01,
+      "woodlands": 0.03,
+      "badlands": 0.02,
+      "lake": 0.01,
+      "floodplain": 0.03
+    }
   },
   "Ceratosaurus": {
     "name": "Ceratosaurus",
@@ -25,7 +34,16 @@
     "hatchling_energy_drain": 0.9,
     "adult_energy_drain": 2.3,
     "walking_energy_drain_multiplier": 1.1,
-    "carcass_food_value_modifier": 0.68
+    "carcass_food_value_modifier": 0.68,
+    "encounter_chance": {
+      "plains": 0.04,
+      "forest": 0.05,
+      "swamp": 0.02,
+      "woodlands": 0.03,
+      "badlands": 0.02,
+      "lake": 0.01,
+      "floodplain": 0.03
+    }
   },
   "Torvosaurus": {
     "name": "Torvosaurus",
@@ -39,7 +57,16 @@
     "hatchling_energy_drain": 1.1,
     "adult_energy_drain": 3.0,
     "walking_energy_drain_multiplier": 1.3,
-    "carcass_food_value_modifier": 0.72
+    "carcass_food_value_modifier": 0.72,
+    "encounter_chance": {
+      "plains": 0.03,
+      "forest": 0.02,
+      "swamp": 0.01,
+      "woodlands": 0.02,
+      "badlands": 0.05,
+      "lake": 0.01,
+      "floodplain": 0.02
+    }
   },
   "Ornitholestes": {
     "name": "Ornitholestes",
@@ -53,7 +80,16 @@
     "hatchling_energy_drain": 0.5,
     "adult_energy_drain": 1.0,
     "walking_energy_drain_multiplier": 1.0,
-    "carcass_food_value_modifier": 0.6
+    "carcass_food_value_modifier": 0.6,
+    "encounter_chance": {
+      "plains": 0.05,
+      "forest": 0.06,
+      "swamp": 0.03,
+      "woodlands": 0.04,
+      "badlands": 0.02,
+      "lake": 0.01,
+      "floodplain": 0.04
+    }
   },
   "Nanosaurus": {
     "name": "Nanosaurus",
@@ -67,7 +103,16 @@
     "hatchling_energy_drain": 0.3,
     "adult_energy_drain": 0.8,
     "walking_energy_drain_multiplier": 1.0,
-    "carcass_food_value_modifier": 0.5
+    "carcass_food_value_modifier": 0.5,
+    "encounter_chance": {
+      "plains": 0.06,
+      "forest": 0.05,
+      "swamp": 0.04,
+      "woodlands": 0.05,
+      "badlands": 0.01,
+      "lake": 0.02,
+      "floodplain": 0.05
+    }
   },
   "Dryosaurus": {
     "name": "Dryosaurus",
@@ -81,7 +126,16 @@
     "hatchling_energy_drain": 0.4,
     "adult_energy_drain": 1.2,
     "walking_energy_drain_multiplier": 1.0,
-    "carcass_food_value_modifier": 0.55
+    "carcass_food_value_modifier": 0.55,
+    "encounter_chance": {
+      "plains": 0.05,
+      "forest": 0.05,
+      "swamp": 0.02,
+      "woodlands": 0.04,
+      "badlands": 0.01,
+      "lake": 0.02,
+      "floodplain": 0.04
+    }
   },
   "Camptosaurus": {
     "name": "Camptosaurus",
@@ -95,7 +149,16 @@
     "hatchling_energy_drain": 0.7,
     "adult_energy_drain": 1.8,
     "walking_energy_drain_multiplier": 1.1,
-    "carcass_food_value_modifier": 0.65
+    "carcass_food_value_modifier": 0.65,
+    "encounter_chance": {
+      "plains": 0.04,
+      "forest": 0.03,
+      "swamp": 0.02,
+      "woodlands": 0.03,
+      "badlands": 0.01,
+      "lake": 0.02,
+      "floodplain": 0.03
+    }
   },
   "Stegosaurus": {
     "name": "Stegosaurus",
@@ -109,6 +172,15 @@
     "hatchling_energy_drain": 0.8,
     "adult_energy_drain": 2.8,
     "walking_energy_drain_multiplier": 1.2,
-    "carcass_food_value_modifier": 0.6
+    "carcass_food_value_modifier": 0.6,
+    "encounter_chance": {
+      "plains": 0.03,
+      "forest": 0.02,
+      "swamp": 0.01,
+      "woodlands": 0.02,
+      "badlands": 0.01,
+      "lake": 0.01,
+      "floodplain": 0.02
+    }
   }
 }

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -12,7 +12,7 @@ with open(STATS_FILE) as f:
 
 
 class Game:
-    def __init__(self, setting: Setting, dinosaur_name: str, width: int = 30, height: int = 20):
+    def __init__(self, setting: Setting, dinosaur_name: str, width: int = 18, height: int = 10):
         self.setting = setting
         dstats = setting.playable_dinos[dinosaur_name]
         base = DINO_STATS.get(dinosaur_name, {"name": dinosaur_name})


### PR DESCRIPTION
## Summary
- shrink default map to 18x10
- extend dinosaur stats with biome encounter chances
- add encounter panel to GUI under movement buttons
- regenerate encounters when staying or moving

## Testing
- `python -m py_compile dino_game.py dinosurvival/*.py`
- `python - <<'PY'
from dinosurvival.game import DINO_STATS
print('dinosaurs', list(DINO_STATS.keys())[:3])
print('encounter_chance of Allosaurus', DINO_STATS['Allosaurus']['encounter_chance']['plains'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6840afaff8ac832ea18677137bb3d7f7