### PR TITLE
Add fierceness & speed to player stats

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -137,14 +137,18 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         for w in encounter_list.winfo_children():
             w.destroy()
         terrain = game.map.terrain_at(game.x, game.y).name
+        player_f = game.player.fierceness or 1
+        player_s = game.player.speed or 1
         for name, stats in DINO_STATS.items():
             chance = stats.get("encounter_chance", {}).get(terrain, 0)
             if random.random() < chance:
                 row = tk.Frame(encounter_list)
                 row.pack(anchor="w", pady=2, fill="x")
-                info = f"{name}  F:{stats.get('adult_fierceness',0)} S:{stats.get('adult_speed',0)}"
-                tk.Label(row, text=info).pack(side="left")
-                tk.Button(row, text="Hunt", width=5).pack(side="right")
+                rel_f = stats.get("adult_fierceness", 0) / player_f
+                rel_s = stats.get("adult_speed", 0) / player_s
+                info = f"{name}  F:{rel_f:.2f} S:{rel_s:.2f}"
+                tk.Label(row, text=info, font=("Helvetica", 12)).pack(side="left")
+                tk.Button(row, text="Hunt", width=7, font=("Helvetica", 12)).pack(side="right")
 
     # Top-right map
     map_frame = tk.Frame(main)
@@ -205,7 +209,9 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
             f"Dinosaur: {dinosaur_name}\n"
             f"Health: {game.player.health:.0f}%\n"
             f"Energy: {game.player.energy:.0f}%\n"
-            f"Weight: {game.player.weight:.1f} kg"
+            f"Weight: {game.player.weight:.1f} kg\n"
+            f"Fierceness: {game.player.fierceness:.1f}\n"
+            f"Speed: {game.player.speed:.1f}"
         )
 
     # Bottom-right stats

--- a/dinosurvival/dinosaur.py
+++ b/dinosurvival/dinosaur.py
@@ -17,6 +17,8 @@ class DinosaurStats:
     adult_energy_drain: float = 0.0
     walking_energy_drain_multiplier: float = 1.0
     carcass_food_value_modifier: float = 1.0
+    fierceness: float = 0.0
+    speed: float = 0.0
     health: float = 100.0
     energy: float = 100.0
     weight: float = 0.0
@@ -28,3 +30,8 @@ class DinosaurStats:
         if self.growth_stages > 0:
             self.growth_stages -= 1
             self.hunger = 0
+            if self.growth_stages == 0:
+                self.weight = self.adult_weight
+                self.fierceness = self.adult_fierceness
+                self.speed = self.adult_speed
+

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -21,6 +21,8 @@ class Game:
         filtered = {k: v for k, v in combined.items() if k in allowed_fields}
         self.player = DinosaurStats(hunger=0, **filtered)
         self.player.weight = self.player.hatchling_weight
+        self.player.fierceness = self.player.hatchling_fierceness
+        self.player.speed = self.player.hatchling_speed
         self.map = Map(width, height, setting.terrains)
         self.x = width // 2
         self.y = height // 2


### PR DESCRIPTION
## Summary
- add new `fierceness` and `speed` fields to `DinosaurStats`
- initialize the player's fierceness and speed
- show fierceness & speed in stats panel
- scale encounter stats relative to the player's values
- make encounter fonts and buttons slightly bigger

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b6bbab90832eb497c8a338e1ee1c