### PR TITLE
Implement energy-based survival

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -103,10 +103,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     btn_frame.pack()
 
     def perform(action: str) -> None:
-        if action == "stay":
-            result = "Stayed put"
-        else:
-            result = game.turn(action)
+        result = game.turn(action)
         append_output(result)
         update_biome()
         update_map()

--- a/dinosurvival/dinosaur.py
+++ b/dinosurvival/dinosaur.py
@@ -3,8 +3,6 @@ from dataclasses import dataclass
 @dataclass
 class DinosaurStats:
     name: str
-    hunger: int
-    hunger_threshold: int
     growth_stages: int
     growth_speed: float = 0.0
     hatchling_weight: float = 0.0
@@ -23,13 +21,13 @@ class DinosaurStats:
     energy: float = 100.0
     weight: float = 0.0
 
-    def is_starving(self) -> bool:
-        return self.hunger >= self.hunger_threshold
+    def is_exhausted(self) -> bool:
+        return self.energy <= 0
 
     def grow(self):
         if self.growth_stages > 0:
             self.growth_stages -= 1
-            self.hunger = 0
+            self.energy = 100.0
             if self.growth_stages == 0:
                 self.weight = self.adult_weight
                 self.fierceness = self.adult_fierceness

--- a/dinosurvival/settings.py
+++ b/dinosurvival/settings.py
@@ -13,10 +13,10 @@ class Setting:
 MORRISON = Setting(
     name="Morrison Formation",
     playable_dinos={
-        "Allosaurus": {"hunger_threshold": 5, "growth_stages": 3},
-        "Ceratosaurus": {"hunger_threshold": 4, "growth_stages": 3},
-        "Torvosaurus": {"hunger_threshold": 5, "growth_stages": 3},
-        "Ornitholestes": {"hunger_threshold": 3, "growth_stages": 3},
+        "Allosaurus": {"energy_threshold": 0, "growth_stages": 3},
+        "Ceratosaurus": {"energy_threshold": 0, "growth_stages": 3},
+        "Torvosaurus": {"energy_threshold": 0, "growth_stages": 3},
+        "Ornitholestes": {"energy_threshold": 0, "growth_stages": 3},
     },
     terrains={
         "plains": Terrain("plains", {"small_prey": 0.8, "large_prey": 0.2}),
@@ -31,8 +31,8 @@ MORRISON = Setting(
 HELL_CREEK = Setting(
     name="Hell Creek",
     playable_dinos={
-        "Tyrannosaurus": {"hunger_threshold": 6, "growth_stages": 4},
-        "Dakotaraptor": {"hunger_threshold": 4, "growth_stages": 3},
+        "Tyrannosaurus": {"energy_threshold": 0, "growth_stages": 4},
+        "Dakotaraptor": {"energy_threshold": 0, "growth_stages": 3},
     },
     terrains={
         "floodplain": Terrain("floodplain", {"small_prey": 0.4, "large_prey": 0.6}),


### PR DESCRIPTION
## Summary
- remove hunger fields from `DinosaurStats` and replace with energy
- drain energy in `Game.turn()` using stats from YAML
- restore energy on successful hunts
- call game logic for the "Stay" button
- update settings to use `energy_threshold`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840c838e35c832e8af06577d6597c72