### PR TITLE
Add health regen and colored stats

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -228,23 +228,43 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
                         width=2,
                     )
 
+    def color_for(val: float) -> str:
+        if val <= 25:
+            return "red"
+        if val <= 50:
+            return "orange"
+        if val <= 75:
+            return "yellow"
+        return "green"
+
     def update_stats() -> None:
-        stats_var.set(
-            f"Dinosaur: {dinosaur_name}\n"
-            f"Health: {game.player.health:.0f}%\n"
-            f"Energy: {game.player.energy:.0f}%\n"
-            f"Weight: {game.player.weight:.1f} kg\n"
-            f"Fierceness: {game.player.fierceness:.1f}\n"
-            f"Speed: {game.player.speed:.1f}"
+        health_label.config(
+            text=f"Health: {game.player.health:.0f}%",
+            fg=color_for(game.player.health),
         )
+        energy_label.config(
+            text=f"Energy: {game.player.energy:.0f}%",
+            fg=color_for(game.player.energy),
+        )
+        weight_label.config(text=f"Weight: {game.player.weight:.1f} kg")
+        fierce_label.config(text=f"Fierceness: {game.player.fierceness:.1f}")
+        speed_label.config(text=f"Speed: {game.player.speed:.1f}")
 
     # Bottom-right stats
     stats_frame = tk.Frame(main)
     stats_frame.grid(row=1, column=1, sticky="nsew", padx=10, pady=10)
 
-    stats_var = tk.StringVar()
-    stats_label = tk.Label(stats_frame, textvariable=stats_var, font=("Helvetica", 16))
-    stats_label.pack()
+    tk.Label(stats_frame, text=f"Dinosaur: {dinosaur_name}", font=("Helvetica", 16)).pack()
+    health_label = tk.Label(stats_frame, font=("Helvetica", 16))
+    health_label.pack()
+    energy_label = tk.Label(stats_frame, font=("Helvetica", 16))
+    energy_label.pack()
+    weight_label = tk.Label(stats_frame, font=("Helvetica", 16))
+    weight_label.pack()
+    fierce_label = tk.Label(stats_frame, font=("Helvetica", 16))
+    fierce_label.pack()
+    speed_label = tk.Label(stats_frame, font=("Helvetica", 16))
+    speed_label.pack()
     tk.Button(stats_frame, text="Quit", width=10, command=root.destroy).pack(pady=10)
 
     # Bottom text output

--- a/dinosurvival/dino_stats.yaml
+++ b/dinosurvival/dino_stats.yaml
@@ -12,6 +12,7 @@
     "adult_energy_drain": 2.5,
     "walking_energy_drain_multiplier": 1.2,
     "carcass_food_value_modifier": 0.7,
+    "health_regen": 2.5,
     "encounter_chance": {
       "plains": 0.05,
       "forest": 0.04,
@@ -35,6 +36,7 @@
     "adult_energy_drain": 2.3,
     "walking_energy_drain_multiplier": 1.1,
     "carcass_food_value_modifier": 0.68,
+    "health_regen": 2.5,
     "encounter_chance": {
       "plains": 0.04,
       "forest": 0.05,
@@ -58,6 +60,7 @@
     "adult_energy_drain": 3.0,
     "walking_energy_drain_multiplier": 1.3,
     "carcass_food_value_modifier": 0.72,
+    "health_regen": 2.5,
     "encounter_chance": {
       "plains": 0.03,
       "forest": 0.02,
@@ -81,6 +84,7 @@
     "adult_energy_drain": 1.0,
     "walking_energy_drain_multiplier": 1.0,
     "carcass_food_value_modifier": 0.6,
+    "health_regen": 2.5,
     "encounter_chance": {
       "plains": 0.05,
       "forest": 0.06,
@@ -104,6 +108,7 @@
     "adult_energy_drain": 0.8,
     "walking_energy_drain_multiplier": 1.0,
     "carcass_food_value_modifier": 0.5,
+    "health_regen": 2.5,
     "encounter_chance": {
       "plains": 0.06,
       "forest": 0.05,
@@ -127,6 +132,7 @@
     "adult_energy_drain": 1.2,
     "walking_energy_drain_multiplier": 1.0,
     "carcass_food_value_modifier": 0.55,
+    "health_regen": 2.5,
     "encounter_chance": {
       "plains": 0.05,
       "forest": 0.05,
@@ -150,6 +156,7 @@
     "adult_energy_drain": 1.8,
     "walking_energy_drain_multiplier": 1.1,
     "carcass_food_value_modifier": 0.65,
+    "health_regen": 2.5,
     "encounter_chance": {
       "plains": 0.04,
       "forest": 0.03,
@@ -173,6 +180,7 @@
     "adult_energy_drain": 2.8,
     "walking_energy_drain_multiplier": 1.2,
     "carcass_food_value_modifier": 0.6,
+    "health_regen": 2.5,
     "encounter_chance": {
       "plains": 0.03,
       "forest": 0.02,

--- a/dinosurvival/dinosaur.py
+++ b/dinosurvival/dinosaur.py
@@ -20,6 +20,7 @@ class DinosaurStats:
     health: float = 100.0
     energy: float = 100.0
     weight: float = 0.0
+    health_regen: float = 0.0
 
     def is_exhausted(self) -> bool:
         return self.energy <= 0

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -110,4 +110,8 @@ class Game:
         if self.player.is_exhausted():
             return result + "\nYou have collapsed from exhaustion! Game Over."
 
+        regen = getattr(self.player, "health_regen", 0.0)
+        if regen:
+            self.player.health = min(100.0, self.player.health + regen)
+
         return result


### PR DESCRIPTION
## Summary
- define `health_regen` in `DinosaurStats`
- add `health_regen: 2.5` to every entry in the stats yaml
- heal the player each turn using the regen value
- display separate colored labels for health and energy in the GUI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840d1241f60832ea380db2f964ac023