### PR TITLE
Improve growth handling

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -262,7 +262,19 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
             text=f"Energy: {game.player.energy:.0f}%",
             fg=color_for(game.player.energy),
         )
-        weight_label.config(text=f"Weight: {game.player.weight:.1f} kg")
+        pct = 0.0
+        growth_range = game.player.adult_weight - game.player.hatchling_weight
+        if growth_range > 0:
+            pct = (
+                (game.player.weight - game.player.hatchling_weight)
+                / growth_range
+            ) * 100
+        weight_label.config(
+            text=(
+                f"Weight: {game.player.weight:.1f}kg/"
+                f"{game.player.adult_weight:.0f}kg ({pct:.1f}%)"
+            )
+        )
         fierce_label.config(text=f"Fierceness: {game.player.fierceness:.1f}")
         speed_label.config(text=f"Speed: {game.player.speed:.1f}")
 

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -79,7 +79,27 @@ class Game:
             )
 
         self.player.energy = 100.0
-        self.player.weight += target_weight * target.get("carcass_food_value_modifier", 1.0)
+        weight_gain = target_weight * target.get("carcass_food_value_modifier", 1.0)
+        weight_gain = min(weight_gain, self.player.growth_speed)
+        self.player.weight = min(
+            self.player.weight + weight_gain,
+            self.player.adult_weight,
+        )
+
+        growth_range = self.player.adult_weight - self.player.hatchling_weight
+        if growth_range > 0:
+            pct = (
+                self.player.weight - self.player.hatchling_weight
+            ) / growth_range
+            self.player.fierceness = (
+                self.player.hatchling_fierceness
+                + pct * (self.player.adult_fierceness - self.player.hatchling_fierceness)
+            )
+            self.player.speed = (
+                self.player.hatchling_speed
+                + pct * (self.player.adult_speed - self.player.hatchling_speed)
+            )
+
         return (
             f"You caught and defeated the {target_name} but lost {damage:.0f}% health."
         )


### PR DESCRIPTION
## Summary
- cap weight gain after a hunt to a dinosaur's `growth_speed`
- update fierceness and speed according to growth
- show adult weight and growth percent in the GUI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840d9406220832e8381eeae55275fa9