### PR TITLE
Add hydration system with drink action

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -57,7 +57,7 @@ def run_game(setting, dinosaur_name: str | None = None):
     else:
         dino_name = dinosaur_name
     game = Game(setting, dino_name)
-    print("Type commands: north, south, east, west, hunt, quit")
+    print("Type commands: north, south, east, west, hunt, drink, quit")
     while True:
         action = input("> ").strip()
         if action == "quit":
@@ -98,6 +98,12 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     def update_biome() -> None:
         terrain = game.map.terrain_at(game.x, game.y)
         biome_var.set(f"Biome: {terrain.name}")
+        update_drink_button()
+
+    def update_drink_button() -> None:
+        terrain = game.map.terrain_at(game.x, game.y)
+        state = "normal" if terrain.name == "lake" else "disabled"
+        move_buttons["drink"].config(state=state)
 
     # Movement buttons
     btn_frame = tk.Frame(control_frame)
@@ -120,8 +126,10 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     move_buttons["east"] = tk.Button(btn_frame, text="East", width=8, command=lambda: perform("east"))
     move_buttons["west"] = tk.Button(btn_frame, text="West", width=8, command=lambda: perform("west"))
     move_buttons["stay"] = tk.Button(btn_frame, text="Stay", width=8, command=lambda: perform("stay"))
+    move_buttons["drink"] = tk.Button(btn_frame, text="Drink", width=8, command=lambda: perform("drink"))
 
     move_buttons["north"].grid(row=0, column=1)
+    move_buttons["drink"].grid(row=0, column=2)
     move_buttons["west"].grid(row=1, column=0)
     move_buttons["stay"].grid(row=1, column=1)
     move_buttons["east"].grid(row=1, column=2)
@@ -139,6 +147,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         result = game.hunt_dinosaur(target_name, juvenile)
         append_output(result)
         update_stats()
+        update_drink_button()
         update_encounters()
         if "Game Over" in result:
             for b in move_buttons.values():
@@ -262,6 +271,10 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
             text=f"Energy: {game.player.energy:.0f}%",
             fg=color_for(game.player.energy),
         )
+        hydration_label.config(
+            text=f"Hydration: {game.player.hydration:.0f}%",
+            fg=color_for(game.player.hydration),
+        )
         pct = 0.0
         growth_range = game.player.adult_weight - game.player.hatchling_weight
         if growth_range > 0:
@@ -287,6 +300,8 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     health_label.pack()
     energy_label = tk.Label(stats_frame, font=("Helvetica", 16))
     energy_label.pack()
+    hydration_label = tk.Label(stats_frame, font=("Helvetica", 16))
+    hydration_label.pack()
     weight_label = tk.Label(stats_frame, font=("Helvetica", 16))
     weight_label.pack()
     fierce_label = tk.Label(stats_frame, font=("Helvetica", 16))

--- a/dinosurvival/dino_stats.yaml
+++ b/dinosurvival/dino_stats.yaml
@@ -13,6 +13,7 @@
     "walking_energy_drain_multiplier": 1.2,
     "carcass_food_value_modifier": 0.7,
     "health_regen": 2.5,
+    "hydration_drain": 2.5,
     "encounter_chance": {
       "plains": 0.05,
       "forest": 0.04,
@@ -37,6 +38,7 @@
     "walking_energy_drain_multiplier": 1.1,
     "carcass_food_value_modifier": 0.68,
     "health_regen": 2.5,
+    "hydration_drain": 2.5,
     "encounter_chance": {
       "plains": 0.04,
       "forest": 0.05,
@@ -61,6 +63,7 @@
     "walking_energy_drain_multiplier": 1.3,
     "carcass_food_value_modifier": 0.72,
     "health_regen": 2.5,
+    "hydration_drain": 2.5,
     "encounter_chance": {
       "plains": 0.03,
       "forest": 0.02,
@@ -85,6 +88,7 @@
     "walking_energy_drain_multiplier": 1.0,
     "carcass_food_value_modifier": 0.6,
     "health_regen": 2.5,
+    "hydration_drain": 2.5,
     "encounter_chance": {
       "plains": 0.05,
       "forest": 0.06,
@@ -109,6 +113,7 @@
     "walking_energy_drain_multiplier": 1.0,
     "carcass_food_value_modifier": 0.5,
     "health_regen": 2.5,
+    "hydration_drain": 2.5,
     "encounter_chance": {
       "plains": 0.06,
       "forest": 0.05,
@@ -133,6 +138,7 @@
     "walking_energy_drain_multiplier": 1.0,
     "carcass_food_value_modifier": 0.55,
     "health_regen": 2.5,
+    "hydration_drain": 2.5,
     "encounter_chance": {
       "plains": 0.05,
       "forest": 0.05,
@@ -157,6 +163,7 @@
     "walking_energy_drain_multiplier": 1.1,
     "carcass_food_value_modifier": 0.65,
     "health_regen": 2.5,
+    "hydration_drain": 2.5,
     "encounter_chance": {
       "plains": 0.04,
       "forest": 0.03,
@@ -181,6 +188,7 @@
     "walking_energy_drain_multiplier": 1.2,
     "carcass_food_value_modifier": 0.6,
     "health_regen": 2.5,
+    "hydration_drain": 2.5,
     "encounter_chance": {
       "plains": 0.03,
       "forest": 0.02,

--- a/dinosurvival/dinosaur.py
+++ b/dinosurvival/dinosaur.py
@@ -21,9 +21,14 @@ class DinosaurStats:
     energy: float = 100.0
     weight: float = 0.0
     health_regen: float = 0.0
+    hydration: float = 100.0
+    hydration_drain: float = 0.0
 
     def is_exhausted(self) -> bool:
         return self.energy <= 0
+
+    def is_dehydrated(self) -> bool:
+        return self.hydration <= 0
 
     def grow(self):
         if self.growth_stages > 0:


### PR DESCRIPTION
## Summary
- add hydration stat to dinosaurs and set per-turn drain in stats file
- multiply energy cost when hunts fail
- implement drinking from lakes including GUI button
- show hydration in stats display

## Testing
- `python -m py_compile dino_game.py dinosurvival/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6841e426be70832ea5492ad4f30edb46