### PR TITLE
Enhance start logic and show danger

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -93,11 +93,17 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
 
     biome_var = tk.StringVar()
     biome_label = tk.Label(control_frame, textvariable=biome_var, font=("Helvetica", 16))
-    biome_label.pack(pady=(0, 10))
+    biome_label.pack(pady=(0, 2))
+
+    danger_var = tk.StringVar()
+    danger_label = tk.Label(control_frame, textvariable=danger_var, font=("Helvetica", 14))
+    danger_label.pack(pady=(0, 10))
 
     def update_biome() -> None:
         terrain = game.map.terrain_at(game.x, game.y)
         biome_var.set(f"Biome: {terrain.name}")
+        danger = game.map.danger_at(game.x, game.y)
+        danger_var.set(f"Danger: {danger:.0f}")
         update_drink_button()
 
     def update_drink_button() -> None:

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -25,7 +25,8 @@ class Game:
         self.player.speed = self.player.hatchling_speed
         self.map = Map(width, height, setting.terrains)
 
-        # Pick a random starting location no more than two tiles from a lake
+        # Pick a random starting location that is within two tiles of a lake but
+        # not on a lake tile itself
         candidates = set()
         for ly in range(height):
             for lx in range(width):
@@ -34,7 +35,8 @@ class Game:
                         for dx in range(-2, 3):
                             nx, ny = lx + dx, ly + dy
                             if 0 <= nx < width and 0 <= ny < height:
-                                candidates.add((nx, ny))
+                                if self.map.terrain_at(nx, ny).name != "lake":
+                                    candidates.add((nx, ny))
         # Fallback to map center if something went wrong
         if candidates:
             self.x, self.y = random.choice(list(candidates))


### PR DESCRIPTION
## Summary
- avoid starting directly on a lake tile
- display current tile danger value in GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fefaf358832e94edd575f895d12b