### PR TITLE
Update UI layout and add dinosaur images

### DIFF
--- a/dinosurvival/dino_stats.yaml
+++ b/dinosurvival/dino_stats.yaml
@@ -2,6 +2,7 @@
   "Allosaurus": {
     "name": "Allosaurus",
     "formations": ["Morrison"],
+    "image": "assets/dinosaurs/allosaurus.png",
     "growth_speed": 10.0,
     "hatchling_weight": 10.0,
     "adult_weight": 3000.0,
@@ -27,6 +28,7 @@
   },
   "Ceratosaurus": {
     "name": "Ceratosaurus",
+    "image": "assets/dinosaurs/ceratosaurus.png",
     "formations": ["Morrison"],
     "growth_speed": 6.0,
     "hatchling_weight": 9.0,
@@ -53,6 +55,7 @@
   },
   "Torvosaurus": {
     "name": "Torvosaurus",
+    "image": "assets/dinosaurs/torvosaurus.png",
     "formations": ["Morrison"],
     "growth_speed": 8.0,
     "hatchling_weight": 12.0,
@@ -79,6 +82,7 @@
   },
   "Ornitholestes": {
     "name": "Ornitholestes",
+    "image": "assets/dinosaurs/ornitholestes.png",
     "formations": ["Morrison"],
     "growth_speed": 2.5,
     "hatchling_weight": 2.0,
@@ -105,6 +109,7 @@
   },
   "Nanosaurus": {
     "name": "Nanosaurus",
+    "image": "assets/dinosaurs/nanosaurus.png",
     "formations": ["Morrison"],
     "growth_speed": 2.8,
     "hatchling_weight": 0.5,
@@ -131,6 +136,7 @@
   },
   "Dryosaurus": {
     "name": "Dryosaurus",
+    "image": "assets/dinosaurs/dryosaurus.png",
     "formations": ["Morrison"],
     "growth_speed": 2.4,
     "hatchling_weight": 1.0,
@@ -157,6 +163,7 @@
   },
   "Camptosaurus": {
     "name": "Camptosaurus",
+    "image": "assets/dinosaurs/camptosaurus.png",
     "formations": ["Morrison"],
     "growth_speed": 2.0,
     "hatchling_weight": 5.0,
@@ -183,6 +190,7 @@
   },
   "Stegosaurus": {
     "name": "Stegosaurus",
+    "image": "assets/dinosaurs/stegosaurus.png",
     "formations": ["Morrison"],
     "growth_speed": 1.5,
     "hatchling_weight": 5.0,


### PR DESCRIPTION
## Summary
- reorganize GUI layout to match new two-row/three-column design
- adjust biome display order and formatting
- preload player dinosaur images
- move movement buttons to bottom right
- show player stats below the dinosaur image
- record future dinosaur image paths in `dino_stats.yaml`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68421e709928832eb6c4a367ad3fbe74