### PR TITLE
Adjust danger and egg rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A simple text-based dinosaur survival game inspired by the BBC "Big Al" game. Th
 
 - Turn based actions: move or hunt on each turn.
 - Random terrain including forests, plains, swamps, woodlands, badlands and lakes that affects the type of prey encountered.
+- Danger increases with hunting and slowly decays, reducing animal encounters on highly hunted tiles.
+- Collecting eggs no longer raises danger, allowing opportunistic meals without scaring off prey.
 - Support for multiple settings such as the Morrison Formation or Hell Creek.
 
 ## Requirements

--- a/dino_game.py
+++ b/dino_game.py
@@ -270,6 +270,8 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         terrain = game.map.terrain_at(game.x, game.y).name
         player_f = game.player.fierceness or 1
         player_s = game.player.speed or 1
+        danger = game.map.danger_at(game.x, game.y)
+        spawn_mult = max(0.0, 1.0 - danger / 100.0)
         entries: list[tuple[str, bool]] = []
         nest_state = game.map.nest_state(game.x, game.y)
         if nest_state and nest_state != "none":
@@ -282,6 +284,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
             if game.setting.formation not in formations:
                 continue
             chance = stats.get("encounter_chance", {}).get(terrain, 0)
+            chance *= spawn_mult
             if random.random() < chance:
                 found.append((name, random.random() < 0.5))
         entries.extend(found)

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -79,6 +79,13 @@ class Game:
 
     def hunt(self):
         terrain = self.map.terrain_at(self.x, self.y)
+        # Danger on the current tile reduces the likelihood of finding prey
+        danger = self.map.danger_at(self.x, self.y)
+        spawn_multiplier = max(0.0, 1.0 - danger / 100.0)
+        if random.random() > spawn_multiplier:
+            self._energy_multiplier = 1.0
+            return "No prey in the area."
+
         prey_type = random.choices(
             list(terrain.spawn_chance.keys()),
             weights=list(terrain.spawn_chance.values()),
@@ -176,7 +183,6 @@ class Game:
         weight_map = {"small": 4.0, "medium": 10.0, "large": 20.0}
         egg_weight = weight_map.get(state, 0.0)
         self.map.take_eggs(self.x, self.y)
-        self.map.increase_danger(self.x, self.y)
 
         energy_gain = 1000 * egg_weight / max(self.player.weight, 0.1)
         needed = 100.0 - self.player.energy


### PR DESCRIPTION
## Summary
- eat eggs without increasing danger
- danger level reduces chances of animal encounters
- document danger rules

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842d2d85d14832e9bba2632a72ce668