### PR TITLE
Fix missing encounter refresh after failed hunt

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -209,7 +209,15 @@ class Game:
         catch_chance = player_speed / (player_speed + target_speed)
         if random.random() > catch_chance:
             msg = f"The {target_name} escaped before you could catch it."
-            msg += self._apply_turn_costs(False, 5.0)
+            end_msg = self._apply_turn_costs(False, 5.0)
+            msg += end_msg
+            self.last_action = "hunt"
+            self._generate_encounters()
+            if "Game Over" in end_msg:
+                return msg
+            attack = self._aggressive_attack_check()
+            if attack:
+                msg += "\n" + attack
             return msg
 
         player_f = max(self.player.fierceness, 0.1)


### PR DESCRIPTION
## Summary
- refresh encounters when prey escapes a hunt

## Testing
- `python -m py_compile dinosurvival/game.py`


------
https://chatgpt.com/codex/tasks/task_e_68436c599b24832e947bfe46bd775245