### PR TITLE
Add info buttons and enhance legacy stats

### DIFF
--- a/dinosurvival/logging_utils.py
+++ b/dinosurvival/logging_utils.py
@@ -73,3 +73,23 @@ def update_hunter_log(formation: str, dino: str, hunts: dict) -> None:
         if kill > 0:
             dsection[prey] = dsection.get(prey, 0) + kill
     save_hunter_stats(data)
+
+
+def get_dino_game_stats(formation: str, dino: str) -> tuple[int, int]:
+    """Return the number of wins and losses recorded for a dinosaur."""
+    wins = 0
+    losses = 0
+    if not os.path.exists(GAME_LOG_PATH):
+        return wins, losses
+    with open(GAME_LOG_PATH) as f:
+        for line in f:
+            parts = line.strip().split("|")
+            if len(parts) < 5:
+                continue
+            form, name, *_rest, result = parts
+            if form == formation and name == dino:
+                if result == "Win":
+                    wins += 1
+                else:
+                    losses += 1
+    return wins, losses


### PR DESCRIPTION
## Summary
- show dinosaur name and image with win rate in legacy stats
- add info button to dinosaur selection screen
- generalize dinosaur facts info
- support info buttons for non-egg encounters
- expose win/loss totals in logging utils

## Testing
- `python -m py_compile dino_game.py dinosurvival/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684c2a074810832e96c5be35bb7b29ca