### PR TITLE
Implement mating mechanics and sex-aware encounters

### DIFF
--- a/dinosurvival/dinosaur.py
+++ b/dinosurvival/dinosaur.py
@@ -24,6 +24,7 @@ class DinosaurStats:
     hydration_drain: float = 0.0
     aquatic_boost: float = 0.0
     forms_packs: bool = False
+    mated: bool = False
 
     def is_exhausted(self) -> bool:
         return self.energy <= 0


### PR DESCRIPTION
## Summary
- display dinosaur info in Game Stats window like Legacy Stats
- show male symbol next to player's species name
- generate encounters that include sex for potential mates
- implement mating action that consumes a turn
- require mating and adulthood for victory
- track mating in player stats panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c63824ec4832ea8c09dd322c041d3