### PR TITLE
Add player stats and expand encounters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,8 @@ menu appears allowing you to pick a dinosaur. Once a dinosaur is chosen the
 window clears and a new interface appears. Use the direction buttons to move
 between squares or stay put and watch the text box at the bottom for game
 updates. The **Quit** button in the stats panel exits the program.
+The stats panel also includes **Player Stats** alongside **Info**, **Game Stats**
+and **Legacy Stats**. This shows your cumulative games played, win rate,
+successful hunts and total turns across all sessions.
 
 Each dinosaur's base attributes are defined in `dinosurvival/dino_stats.yaml`.

--- a/dino_game.py
+++ b/dino_game.py
@@ -9,6 +9,7 @@ from dinosurvival.logging_utils import (
     update_hunter_log,
     load_hunter_stats,
     get_dino_game_stats,
+    get_player_stats,
 )
 
 try:
@@ -324,10 +325,40 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     def show_legacy_stats() -> None:
         display_legacy_stats(root, game.setting.formation, dinosaur_name)
 
+    def show_player_stats() -> None:
+        games, wins, hunts, turns = get_player_stats(
+            game.setting.formation, dinosaur_name
+        )
+        win_rate = (wins / games * 100) if games else 0.0
+        win = tk.Toplevel(root)
+        win.title("Player Stats")
+        info = DINO_STATS.get(dinosaur_name, {})
+        img = None
+        img_path = info.get("image")
+        if img_path:
+            abs_path = os.path.join(os.path.dirname(__file__), img_path)
+            img = load_scaled_image(abs_path, 400, 250, master=win)
+        if img:
+            lbl = tk.Label(win, image=img)
+            lbl.image = img
+            lbl.pack()
+        tk.Label(win, text=dinosaur_name + " \u2642", font=("Helvetica", 18)).pack(
+            pady=5
+        )
+        lines = [
+            f"Games played: {games} ({win_rate:.0f}% win rate)",
+            f"Successful hunts: {hunts}",
+            f"Lifetime turns: {turns}",
+        ]
+        for l in lines:
+            tk.Label(win, text=l, font=("Helvetica", 12), anchor="w").pack(anchor="w")
+        tk.Button(win, text="Close", command=win.destroy).pack(pady=5)
+
     button_row = tk.Frame(dino_frame)
     tk.Button(button_row, text="Info", command=show_dino_facts).pack(side="left", padx=2)
     tk.Button(button_row, text="Game Stats", command=show_game_stats).pack(side="left", padx=2)
     tk.Button(button_row, text="Legacy Stats", command=show_legacy_stats).pack(side="left", padx=2)
+    tk.Button(button_row, text="Player Stats", command=show_player_stats).pack(side="left", padx=2)
     button_row.pack(pady=5)
 
     def update_biome() -> None:
@@ -416,7 +447,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     encounter_list.pack(fill="both", expand=True)
     encounter_rows = []
     encounter_images: dict[str, tk.PhotoImage] = {}
-    for _ in range(4):
+    for _ in range(5):
         row = tk.Frame(encounter_list)
         img = tk.Label(row)
         info_frame = tk.Frame(row)

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -97,7 +97,7 @@ class Game:
         spawn_mult = max(0.0, 1.0 - danger / 100.0)
         found: list[tuple[str, bool, str | None]] = []
         for name, stats in DINO_STATS.items():
-            if len(found) >= 4:
+            if len(found) >= 5:
                 break
             formations = stats.get("formations", [])
             if self.setting.formation not in formations:
@@ -128,7 +128,7 @@ class Game:
             entries.append((self.player.name, j, True, None))
         for name, juvenile, sex in found:
             entries.append((name, juvenile, False, sex))
-        self.current_encounters = entries[:4]
+        self.current_encounters = entries[:5]
 
     def _aggressive_attack_check(self) -> Optional[str]:
         player_f = max(self.effective_fierceness(), 0.1)

--- a/dinosurvival/logging_utils.py
+++ b/dinosurvival/logging_utils.py
@@ -93,3 +93,36 @@ def get_dino_game_stats(formation: str, dino: str) -> tuple[int, int]:
                 else:
                     losses += 1
     return wins, losses
+
+
+def get_player_stats(formation: str, dino: str) -> tuple[int, int, int, int]:
+    """Return total games, wins, successful hunts and turns for a dinosaur."""
+    games = 0
+    wins = 0
+    turns = 0
+    if os.path.exists(GAME_LOG_PATH):
+        with open(GAME_LOG_PATH) as f:
+            for line in f:
+                parts = line.strip().split("|")
+                if len(parts) < 5:
+                    continue
+                form, name, turn_str, *_rest, result = parts
+                if form == formation and name == dino:
+                    games += 1
+                    if result == "Win":
+                        wins += 1
+                    try:
+                        turns += int(turn_str)
+                    except ValueError:
+                        pass
+
+    hunts = 0
+    data = load_hunter_stats()
+    section = data.get(formation, {}).get(dino, {})
+    for val in section.values():
+        try:
+            hunts += int(val)
+        except (TypeError, ValueError):
+            pass
+
+    return games, wins, hunts, turns


### PR DESCRIPTION
## Summary
- show aggregated player stats via new `Player Stats` button
- compute player stats from log files
- allow up to five encounters at once
- document new button in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c886ff640832ebc753a4f70687fa7