### PR TITLE
Update player stats to aggregate all dinosaurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ window clears and a new interface appears. Use the direction buttons to move
 between squares or stay put and watch the text box at the bottom for game
 updates. The **Quit** button in the stats panel exits the program.
 The stats panel also includes **Player Stats** alongside **Info**, **Game Stats**
-and **Legacy Stats**. This shows your cumulative games played, win rate,
-successful hunts and total turns across all sessions.
+and **Legacy Stats**. Player Stats show your cumulative games played, win rate,
+successful hunts and total turns across every dinosaur you've played.
 
 Each dinosaur's base attributes are defined in `dinosurvival/dino_stats.yaml`.

--- a/dino_game.py
+++ b/dino_game.py
@@ -326,25 +326,11 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         display_legacy_stats(root, game.setting.formation, dinosaur_name)
 
     def show_player_stats() -> None:
-        games, wins, hunts, turns = get_player_stats(
-            game.setting.formation, dinosaur_name
-        )
+        games, wins, hunts, turns = get_player_stats()
         win_rate = (wins / games * 100) if games else 0.0
         win = tk.Toplevel(root)
         win.title("Player Stats")
-        info = DINO_STATS.get(dinosaur_name, {})
-        img = None
-        img_path = info.get("image")
-        if img_path:
-            abs_path = os.path.join(os.path.dirname(__file__), img_path)
-            img = load_scaled_image(abs_path, 400, 250, master=win)
-        if img:
-            lbl = tk.Label(win, image=img)
-            lbl.image = img
-            lbl.pack()
-        tk.Label(win, text=dinosaur_name + " \u2642", font=("Helvetica", 18)).pack(
-            pady=5
-        )
+        tk.Label(win, text="Player Stats", font=("Helvetica", 18)).pack(pady=5)
         lines = [
             f"Games played: {games} ({win_rate:.0f}% win rate)",
             f"Successful hunts: {hunts}",

--- a/dinosurvival/logging_utils.py
+++ b/dinosurvival/logging_utils.py
@@ -95,34 +95,35 @@ def get_dino_game_stats(formation: str, dino: str) -> tuple[int, int]:
     return wins, losses
 
 
-def get_player_stats(formation: str, dino: str) -> tuple[int, int, int, int]:
-    """Return total games, wins, successful hunts and turns for a dinosaur."""
+def get_player_stats() -> tuple[int, int, int, int]:
+    """Return total games, wins, successful hunts and turns across all dinosaurs."""
     games = 0
     wins = 0
     turns = 0
+
     if os.path.exists(GAME_LOG_PATH):
         with open(GAME_LOG_PATH) as f:
             for line in f:
                 parts = line.strip().split("|")
                 if len(parts) < 5:
                     continue
-                form, name, turn_str, *_rest, result = parts
-                if form == formation and name == dino:
-                    games += 1
-                    if result == "Win":
-                        wins += 1
-                    try:
-                        turns += int(turn_str)
-                    except ValueError:
-                        pass
+                _form, _name, turn_str, *_rest, result = parts
+                games += 1
+                if result == "Win":
+                    wins += 1
+                try:
+                    turns += int(turn_str)
+                except ValueError:
+                    pass
 
     hunts = 0
     data = load_hunter_stats()
-    section = data.get(formation, {}).get(dino, {})
-    for val in section.values():
-        try:
-            hunts += int(val)
-        except (TypeError, ValueError):
-            pass
+    for form in data.values():
+        for dsection in form.values():
+            for val in dsection.values():
+                try:
+                    hunts += int(val)
+                except (TypeError, ValueError):
+                    pass
 
     return games, wins, hunts, turns


### PR DESCRIPTION
## Summary
- sum player stats across all dinosaurs
- simplify player stats display
- document player stats in README

## Testing
- `python -m py_compile dinosurvival/logging_utils.py dino_game.py`

------
https://chatgpt.com/codex/tasks/task_e_684c8b464ff4832ea5931382b4731958