### PR TITLE
Add mountain biome to final statistics

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -775,7 +775,8 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
             "",
             "Biome Visits:",
         ]
-        for b, c in game.biome_turns.items():
+        for b in game.setting.terrains.keys():
+            c = game.biome_turns.get(b, 0)
             lines.append(f"- {b.capitalize()}: {c}")
         lines.append("")
         lines.append("Hunts:")

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -94,7 +94,10 @@ class Game:
         self.last_action: Optional[str] = None
         # Tracking and win state
         self.turn_count = 0
-        self.biome_turns: dict[str, int] = {}
+        # Track how many turns the player spends in each biome
+        self.biome_turns: dict[str, int] = {
+            name: 0 for name in setting.terrains.keys()
+        }
         self.hunt_stats: dict[str, list[int]] = {}
         self.won = False
 


### PR DESCRIPTION
## Summary
- initialize `biome_turns` with all terrain names
- report all biomes in the final stats popup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5fe6219c832e85277c89f1e52bc2