### PR TITLE
Reveal full map for debugging

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -19,7 +19,7 @@ def calculate_catch_chance(rel_speed: float) -> float:
         return 1.0 - (rel_speed - 0.5)
     return 0.0
 from .dinosaur import DinosaurStats
-from .map import Map
+from .map import Map, map_reveal
 from .settings import Setting
 
 # Constants used to derive hatchling values from adult stats
@@ -67,6 +67,7 @@ class Game:
             setting.height_levels,
             setting.humidity_levels,
         )
+        map_reveal(self.map)
 
         # Pick a random starting location that is within two tiles of a lake but
         # not on a lake tile itself

--- a/dinosurvival/map.py
+++ b/dinosurvival/map.py
@@ -214,3 +214,10 @@ class Map:
                 row.append(val)
             noise.append(row)
         return noise
+
+
+def map_reveal(m: "Map") -> None:
+    """Reveal the entire map for debugging purposes."""
+    for y in range(m.height):
+        for x in range(m.width):
+            m.reveal(x, y)


### PR DESCRIPTION
## Summary
- add `map_reveal` helper in `map.py` to reveal entire map
- call `map_reveal` at the start of `Game` initialization

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d648e92c4832e8383965f63874b96