### PR TITLE
Add persistent NPC animals and disable pack

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -598,7 +598,8 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
                     and name == game.player.name
                     and game.player.weight >= game.player.adult_weight / 100
                 ):
-                    slot["btn"].configure(command=lambda j=juvenile: do_pack_up(j), text="Pack")
+                    # Pack functionality disabled for now
+                    slot["btn"].configure(command=lambda n=name, j=juvenile: do_hunt(n, j), text="Hunt")
                 else:
                     slot["btn"].configure(command=lambda n=name, j=juvenile: do_hunt(n, j), text="Hunt")
                 slot["info"].configure(command=lambda n=name: show_dino_facts(n))

--- a/dinosurvival/map.py
+++ b/dinosurvival/map.py
@@ -111,6 +111,11 @@ class Map:
         self.revealed = [[False for _ in range(width)] for _ in range(height)]
         self.danger = [[0.0 for _ in range(width)] for _ in range(height)]
         self.nests: Dict[Tuple[int, int], Nest] = {}
+        # List of animals present in each cell. Each entry is a list of
+        # tuples ``(name, juvenile, sex)`` where ``sex`` may be ``None``.
+        self.animals: List[List[List[tuple[str, bool, str | None]]]] = [
+            [[] for _ in range(width)] for _ in range(height)
+        ]
 
         # Place 5 nests randomly across the map
         num_nests = 5
@@ -173,6 +178,30 @@ class Map:
             nest.eggs = "none"
             return eggs
         return None
+
+    def remove_animal(
+        self,
+        x: int,
+        y: int,
+        name: str,
+        juvenile: Optional[bool] = None,
+        sex: Optional[str] = None,
+    ) -> bool:
+        """Remove an animal from the specified cell.
+
+        Returns ``True`` if an animal was removed.
+        """
+        cell = self.animals[y][x]
+        for idx, (n, j, s) in enumerate(cell):
+            if n != name:
+                continue
+            if juvenile is not None and j != juvenile:
+                continue
+            if sex is not None and s != sex:
+                continue
+            del cell[idx]
+            return True
+        return False
 
     def _generate_noise(self, width: int, height: int, scale: int = 3) -> List[List[float]]:
         """Create a simple value noise map for distributing biomes.


### PR DESCRIPTION
## Summary
- store animals for each cell in `Map`
- populate animal lists at game start
- reference existing animals when generating encounters
- remove animals from a cell when hunted, mated or packed up
- disable the Pack button in the UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853495bdadc832e8b8ddc7e4510a190