### PR TITLE
Fix plant encounter UI

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -420,7 +420,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
 
     # Plant display below encounters
     plant_list = tk.Frame(encounter_frame)
-    plant_list.pack(fill="both", expand=True)
+    plant_list.pack(fill="both", expand=True, side="bottom")
     plant_rows = []
     plant_images: dict[str, tk.PhotoImage] = {}
     for _ in range(5):
@@ -638,8 +638,8 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         for slot in plant_rows:
             slot["frame"].pack_forget()
         for slot, plant in zip(plant_rows, game.current_plants):
-            stats = PLANT_STATS.get(plant.name, {})
-            img_path = stats.get("image")
+            stats = PLANT_STATS.get(plant.name)
+            img_path = stats.image if stats else None
             img = None
             if img_path:
                 abs_path = os.path.join(os.path.dirname(__file__), img_path)

--- a/tests/test_plants.py
+++ b/tests/test_plants.py
@@ -1,0 +1,30 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import random
+from dinosurvival.plant import PlantStats
+from dinosurvival.settings import MORRISON
+import dinosurvival.game as game_mod
+
+
+def test_plant_stats_dataclass():
+    for stats in game_mod.PLANT_STATS.values():
+        assert isinstance(stats, PlantStats)
+
+
+def test_plants_generated_and_encounters(monkeypatch):
+    custom_stats = {
+        "TestPlant": PlantStats(
+            name="TestPlant",
+            formations=["Morrison"],
+            image="",
+            weight=1.0,
+            growth_chance={terrain: 1.0 for terrain in MORRISON.terrains}
+        )
+    }
+    monkeypatch.setattr(game_mod, "PLANT_STATS", custom_stats)
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.turn("stay")
+    assert len(game.current_plants) > 0
+    assert game.current_plants[0].name == "TestPlant"
+


### PR DESCRIPTION
## Summary
- reposition plants below animals in encounter UI
- handle PlantStats dataclasses when displaying plant images
- add tests for plant stats and plant encounters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68547d30878c832e9c1ea167a79aa05e