### PR TITLE
Add NPC tracking and herbivore feeding

### DIFF
--- a/dinosurvival/dinosaur.py
+++ b/dinosurvival/dinosaur.py
@@ -44,3 +44,15 @@ class DinosaurStats:
         return self.hydration <= 0
 
 
+@dataclass
+class NPCAnimal:
+    """State for a non-player animal present on the map."""
+
+    name: str
+    juvenile: bool
+    sex: str | None
+    energy: float = 100.0
+    health: float = 100.0
+    weight: float = 0.0
+
+

--- a/tests/test_plants.py
+++ b/tests/test_plants.py
@@ -1,7 +1,8 @@
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import random
-from dinosurvival.plant import PlantStats
+from dinosurvival.plant import PlantStats, Plant
+from dinosurvival.dinosaur import NPCAnimal
 from dinosurvival.settings import MORRISON
 import dinosurvival.game as game_mod
 
@@ -27,4 +28,52 @@ def test_plants_generated_and_encounters(monkeypatch):
     game.turn("stay")
     assert len(game.current_plants) > 0
     assert game.current_plants[0].name == "TestPlant"
+
+
+def test_max_two_plants_per_tile(monkeypatch):
+    custom_stats = {
+        "TP": PlantStats(
+            name="TP",
+            formations=["Morrison"],
+            image="",
+            weight=1.0,
+            growth_chance={terrain: 1.0 for terrain in MORRISON.terrains},
+        )
+    }
+    monkeypatch.setattr(game_mod, "PLANT_STATS", custom_stats)
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    for _ in range(5):
+        game.turn("stay")
+    assert len(game.map.plants[0][0]) <= 2
+
+
+def test_npc_state_and_feeding(monkeypatch):
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    # clear existing
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    game.map.plants = [[[] for _ in range(6)] for _ in range(6)]
+    npc = NPCAnimal(name="Stegosaurus", juvenile=False, sex=None, energy=50.0, weight=10.0)
+    game.map.animals[0][0] = [npc]
+    game.map.plants[0][0] = [Plant(name="Ferns", weight=20.0)]
+    game._update_npcs()
+    assert npc.energy > 50.0
+    assert npc.weight > 10.0
+    assert game.map.plants[0][0][0].weight < 20.0
+
+
+def test_npc_initial_state():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    for row in game.map.animals:
+        for cell in row:
+            for npc in cell:
+                assert npc.energy == 100.0
+                assert npc.health == 100.0
+                stats = game_mod.DINO_STATS[npc.name]
+                if stats.get("can_be_juvenile", True):
+                    assert 3.0 <= npc.weight <= stats.get("adult_weight", 0.0)
+                else:
+                    assert npc.weight == stats.get("adult_weight", 0.0)
 


### PR DESCRIPTION
## Summary
- enforce a maximum of two plants per tile
- track NPC energy, health and weight via new `NPCAnimal` dataclass
- spawn animals with weight limits and initial stats
- implement NPC herbivore food selection and consumption
- test new limits and behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b9f91dd4832e839c54de2040196f