### PR TITLE
Track NPC id and age

### DIFF
--- a/dinosurvival/dinosaur.py
+++ b/dinosurvival/dinosaur.py
@@ -48,11 +48,12 @@ class DinosaurStats:
 class NPCAnimal:
     """State for a non-player animal present on the map."""
 
+    id: int
     name: str
-    juvenile: bool
     sex: str | None
+    weight: float = 0.0
+    age: int = 0
     energy: float = 100.0
     health: float = 100.0
-    weight: float = 0.0
 
 

--- a/dinosurvival/map.py
+++ b/dinosurvival/map.py
@@ -186,9 +186,9 @@ class Map:
         self,
         x: int,
         y: int,
-        name: str,
-        juvenile: Optional[bool] = None,
+        name: Optional[str] = None,
         sex: Optional[str] = None,
+        npc_id: Optional[int] = None,
     ) -> bool:
         """Remove an animal from the specified cell.
 
@@ -196,9 +196,9 @@ class Map:
         """
         cell = self.animals[y][x]
         for idx, npc in enumerate(cell):
-            if npc.name != name:
+            if npc_id is not None and npc.id != npc_id:
                 continue
-            if juvenile is not None and npc.juvenile != juvenile:
+            if name is not None and npc.name != name:
                 continue
             if sex is not None and npc.sex != sex:
                 continue

--- a/tests/test_plants.py
+++ b/tests/test_plants.py
@@ -54,7 +54,7 @@ def test_npc_state_and_feeding(monkeypatch):
     # clear existing
     game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
     game.map.plants = [[[] for _ in range(6)] for _ in range(6)]
-    npc = NPCAnimal(name="Stegosaurus", juvenile=False, sex=None, energy=50.0, weight=10.0)
+    npc = NPCAnimal(id=1, name="Stegosaurus", sex=None, energy=50.0, weight=10.0)
     game.map.animals[0][0] = [npc]
     game.map.plants[0][0] = [Plant(name="Ferns", weight=20.0)]
     game._update_npcs()


### PR DESCRIPTION
## Summary
- drop `juvenile` flag from `NPCAnimal` and add `id` and `age`
- update map animal removal to use id
- interpolate NPC stats from weight
- overhaul encounter UI to show weight, age and id
- adjust tests for new `NPCAnimal` signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c01b9f04832eace2da64bae04442