### PR TITLE
Add carcass spoilage logs and turn prefixes

### DIFF
--- a/dinosurvival/dinosaur.py
+++ b/dinosurvival/dinosaur.py
@@ -55,5 +55,7 @@ class NPCAnimal:
     energy: float = 100.0
     health: float = 100.0
     alive: bool = True
+    fierceness: float = 0.0
+    speed: float = 0.0
 
 


### PR DESCRIPTION
## Summary
- track NPC carcass spoilage and eating events
- allow feeding from carcasses
- prefix output lines with current turn number

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856640a3588832eadc0190249d74c3e