### PR TITLE
Handle carcass cleanup before encounters

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -160,6 +160,10 @@ class Game:
         """Load encounter information from the current cell."""
         entries: list[EncounterEntry] = []
         cell_animals = self.map.animals[self.y][self.x]
+        for npc in list(cell_animals):
+            if npc.weight <= 0:
+                cell_animals.remove(npc)
+                continue
         cell_plants = self.map.plants[self.y][self.x]
         nest_state = self.map.nest_state(self.x, self.y)
         if nest_state and nest_state != "none":
@@ -409,6 +413,10 @@ class Game:
                 animals = self.map.animals[y][x]
                 plants = self.map.plants[y][x]
                 for npc in list(animals):
+                    if npc.weight <= 0:
+                        if npc in animals:
+                            animals.remove(npc)
+                        continue
                     if not npc.alive:
                         before = npc.weight
                         npc.weight -= npc.weight * 0.10 + 2

--- a/tests/test_carcass_spoilage.py
+++ b/tests/test_carcass_spoilage.py
@@ -1,0 +1,30 @@
+import os, sys, random
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import dinosurvival.game as game_mod
+from dinosurvival.dinosaur import NPCAnimal
+from dinosurvival.settings import MORRISON
+
+
+def test_carcass_removed_after_spoilage():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    # clear animals
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    carcass = NPCAnimal(id=1, name="Stegosaurus", sex=None, alive=False, weight=1.0)
+    game.map.animals[game.y][game.x] = [carcass]
+    game._generate_encounters()
+    assert any(e.npc is carcass for e in game.current_encounters)
+    game.turn("stay")
+    assert all(e.npc is not carcass for e in game.current_encounters)
+    assert carcass not in game.map.animals[game.y][game.x]
+
+
+def test_zero_weight_removed_on_generate():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    carcass = NPCAnimal(id=2, name="Stegosaurus", sex=None, alive=False, weight=0.0)
+    game.map.animals[game.y][game.x] = [carcass]
+    game._generate_encounters()
+    assert carcass not in game.map.animals[game.y][game.x]
+    assert all(e.npc is not carcass for e in game.current_encounters)


### PR DESCRIPTION
## Summary
- remove zero-weight animals when NPCs update
- filter zero-weight animals from encounters
- add regression tests for carcass spoilage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856679ba9b0832ebd2f2a5452179cef