### PR TITLE
Handle starvation deaths

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -445,6 +445,12 @@ class Game:
                     npc.age += 1
                     stats = DINO_STATS.get(npc.name, {})
                     npc.energy = max(0.0, npc.energy - stats.get("adult_energy_drain", 0.0))
+                    if npc.energy <= 0:
+                        npc.alive = False
+                        npc.age = -1
+                        npc.fierceness = 0.0
+                        npc.speed = 0.0
+                        continue
                     regen = stats.get("health_regen", 0.0)
                     if npc.health < 100.0 and regen:
                         npc.health = min(100.0, npc.health + regen)

--- a/tests/test_energy_death.py
+++ b/tests/test_energy_death.py
@@ -1,0 +1,20 @@
+import random
+import dinosurvival.game as game_mod
+from dinosurvival.dinosaur import NPCAnimal
+from dinosurvival.settings import MORRISON
+
+
+def test_npc_starves_and_carcass_decays():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    npc = NPCAnimal(id=1, name="Allosaurus", sex=None, energy=1.0, weight=10.0)
+    game.map.animals[0][0] = [npc]
+
+    game._update_npcs()
+    assert not npc.alive
+    assert npc.energy == 0.0
+
+    before = npc.weight
+    game._spoil_carcasses()
+    assert npc.weight < before


### PR DESCRIPTION
## Summary
- non-player animals die when their energy reaches 0
- add regression test for NPC starvation and carcass decay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856844734e0832e8d80c303d669d7e4