### PR TITLE
Refine hunt stats and carcass UI

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -603,7 +603,8 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
             ):
                 slot["btn"].configure(command=lambda i=npc.id: do_mate(i), text="Mate")
             else:
-                slot["btn"].configure(command=lambda i=npc.id: do_hunt(i), text="Hunt")
+                label = "Hunt" if npc.alive else "Eat"
+                slot["btn"].configure(command=lambda i=npc.id: do_hunt(i), text=label)
             slot["info"].configure(command=lambda n=npc.name: show_dino_facts(n))
             slot["info"].grid()
             slot["frame"].pack(fill="x", pady=2, expand=True)

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -536,8 +536,11 @@ class Game:
         if target is None:
             return self._finish_turn("Unknown target.")
 
-        hunt = self.hunt_stats.setdefault(target.name, [0, 0])
-        hunt[0] += 1
+        was_alive = target.alive
+        hunt = None
+        if was_alive:
+            hunt = self.hunt_stats.setdefault(target.name, [0, 0])
+            hunt[0] += 1
 
         stats = DINO_STATS.get(target.name, {})
 
@@ -611,7 +614,8 @@ class Game:
         target.weight = max(0.0, target.weight - consumed)
         if target.weight <= 0:
             self.map.remove_animal(self.x, self.y, npc_id=target.id)
-        hunt[1] += 1
+        if was_alive and hunt is not None:
+            hunt[1] += 1
 
         if damage > 0:
             msg = (

--- a/tests/test_hunts.py
+++ b/tests/test_hunts.py
@@ -1,0 +1,25 @@
+import random
+import dinosurvival.game as game_mod
+from dinosurvival.dinosaur import NPCAnimal
+from dinosurvival.settings import MORRISON
+
+
+def test_live_hunt_counts_kill():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    # Clear animals
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    npc = NPCAnimal(id=1, name="Stegosaurus", sex=None, weight=1.0)
+    game.map.animals[game.y][game.x] = [npc]
+    game.hunt_npc(npc.id)
+    assert game.hunt_stats.get("Stegosaurus", [0, 0])[1] == 1
+
+
+def test_carcass_eat_not_counted_as_hunt():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    carcass = NPCAnimal(id=1, name="Stegosaurus", sex=None, alive=False, weight=1.0)
+    game.map.animals[game.y][game.x] = [carcass]
+    game.hunt_npc(carcass.id)
+    assert "Stegosaurus" not in game.hunt_stats


### PR DESCRIPTION
## Summary
- adjust hunt tracking so carcass meals don't count as kills
- show `Eat` instead of `Hunt` for dead targets
- cover hunting behaviour in new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685687375f78832eb3f8084fbc9aae00