### PR TITLE
Display coords & egg logging

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -367,6 +367,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         label = terrain.name.capitalize()
         if game.map.has_nest(game.x, game.y):
             label += " (Nest)"
+        label += f" ({game.x},{game.y})"
         biome_var.set(label)
         img = biome_images.get(terrain.name)
         if img:

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -23,6 +23,7 @@ from .dinosaur import DinosaurStats, Diet, NPCAnimal
 from .plant import PlantStats, Plant
 from .map import Map, EggCluster
 from .settings import Setting
+from .logging_utils import append_event_log
 
 # Constants used to derive hatchling values from adult stats
 HATCHLING_WEIGHT_DIVISOR = 1000
@@ -506,6 +507,7 @@ class Game:
                             turns_until_hatch=5,
                         )
                         self.map.add_eggs(x, y, eggs)
+                        append_event_log(f"{npc.name} laid eggs at ({x},{y})")
                         npc.turns_until_lay_eggs = stats.get("egg_laying_interval", 0)
                         if x == self.x and y == self.y:
                             messages.append(f"The {npc.name} lays eggs.")

--- a/dinosurvival/logging_utils.py
+++ b/dinosurvival/logging_utils.py
@@ -65,6 +65,12 @@ def append_game_log(formation: str, dino: str, turns: int, weight: float, won: b
         f.write(line)
 
 
+def append_event_log(message: str) -> None:
+    """Append a simple event message to the game log."""
+    with open(GAME_LOG_PATH, "a") as f:
+        f.write(f"EVENT|{message}\n")
+
+
 def update_hunter_log(formation: str, dino: str, hunts: dict) -> None:
     data = load_hunter_stats()
     form = data.setdefault(formation, {})


### PR DESCRIPTION
## Summary
- show player coordinates in biome label
- log NPC egg laying events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68573aba42bc832e9cae5dd4a05f983a