### PR TITLE
Fix graph size

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -272,8 +272,8 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
 
         counts = game.population_history.get(name, [])
         if counts:
-            width, height = 400, 250
-            margin = 30
+            width, height = 320, 200
+            margin = 24
             canvas = tk.Canvas(win, width=width + margin, height=height + margin)
             max_c = max(counts)
             max_c = max(max_c, 1)


### PR DESCRIPTION
## Summary
- make the population graph smaller so labels aren't clipped

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857daf25a70832ea1ffe409c6c60bd9