### PR TITLE
Fix population graph cropping

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -274,26 +274,55 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         if counts:
             width, height = 320, 200
             margin = 24
-            canvas = tk.Canvas(win, width=width + margin, height=height + margin)
+            top_pad = 10
+            right_pad = 10
+            canvas = tk.Canvas(
+                win,
+                width=width + margin + right_pad,
+                height=height + margin + top_pad,
+            )
             max_c = max(counts)
             max_c = max(max_c, 1)
             step = width / max(len(counts) - 1, 1)
-            canvas.create_line(margin, 0, margin, height)
-            canvas.create_line(margin, height, margin + width, height)
+            canvas.create_line(margin, top_pad, margin, top_pad + height)
+            canvas.create_line(margin, top_pad + height, margin + width, top_pad + height)
             for i in range(1, len(counts)):
                 x1 = margin + (i - 1) * step
-                y1 = height - counts[i - 1] / max_c * height
+                y1 = top_pad + height - counts[i - 1] / max_c * height
                 x2 = margin + i * step
-                y2 = height - counts[i] / max_c * height
+                y2 = top_pad + height - counts[i] / max_c * height
                 canvas.create_line(x1, y1, x2, y2, fill="blue")
-            canvas.create_text(margin - 5, height, text="0", anchor="e", font=("Helvetica", 8))
-            canvas.create_text(margin - 5, height - height, text=str(max_c), anchor="e", font=("Helvetica", 8))
+            canvas.create_text(margin - 5, top_pad + height, text="0", anchor="e", font=("Helvetica", 8))
+            canvas.create_text(margin - 5, top_pad, text=str(max_c), anchor="e", font=("Helvetica", 8))
             turns = game.turn_history
             if turns:
-                canvas.create_text(margin, height + 10, text=str(turns[0]), anchor="n", font=("Helvetica", 8))
-                canvas.create_text(margin + width, height + 10, text=str(turns[-1]), anchor="n", font=("Helvetica", 8))
-            canvas.create_text(margin + width / 2, height + 20, text="Turn", font=("Helvetica", 10))
-            canvas.create_text(10, height / 2, text="Population", angle=90, font=("Helvetica", 10))
+                canvas.create_text(
+                    margin,
+                    top_pad + height + 10,
+                    text=str(turns[0]),
+                    anchor="n",
+                    font=("Helvetica", 8),
+                )
+                canvas.create_text(
+                    margin + width,
+                    top_pad + height + 10,
+                    text=str(turns[-1]),
+                    anchor="n",
+                    font=("Helvetica", 8),
+                )
+            canvas.create_text(
+                margin + width / 2,
+                top_pad + height + 20,
+                text="Turn",
+                font=("Helvetica", 10),
+            )
+            canvas.create_text(
+                10,
+                top_pad + height / 2,
+                text="Population",
+                angle=90,
+                font=("Helvetica", 10),
+            )
             canvas.pack()
 
         tk.Label(win, text=name, font=("Helvetica", 18)).pack(pady=5)


### PR DESCRIPTION
## Summary
- adjust canvas dimensions and offsets in `show_dino_facts` to leave padding on the top and right of the population graph

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857dd4bcb84832e943c7a9505f42ba0