### PR TITLE
Support fruit diet for NPC feeding

### DIFF
--- a/dinosurvival/dinosaur.py
+++ b/dinosurvival/dinosaur.py
@@ -8,6 +8,7 @@ class Diet(Enum):
     FERNS = "ferns"
     CYCADS = "cycads"
     CONIFERS = "conifers"
+    FRUITS = "fruits"
 
 @dataclass
 class DinosaurStats:

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -636,8 +636,8 @@ class Game:
                             npc.next_move = "None"
                             continue
 
-                    if plants and any(d in diet for d in (Diet.FERNS, Diet.CYCADS, Diet.CONIFERS)):
-                        options = [p for p in plants if p.name.lower() in ("ferns", "cycads", "conifers")]
+                    if plants and any(d in diet for d in (Diet.FERNS, Diet.CYCADS, Diet.CONIFERS, Diet.FRUITS)):
+                        options = [p for p in plants if p.name.lower() in ("ferns", "cycads", "conifers", "fruits")]
                         if options:
                             chosen = max(options, key=lambda p: p.weight)
                             eaten = self._npc_consume_plant(npc, chosen, stats)

--- a/tests/test_plants.py
+++ b/tests/test_plants.py
@@ -63,6 +63,20 @@ def test_npc_state_and_feeding(monkeypatch):
     assert game.map.plants[0][0][0].weight < 20.0
 
 
+def test_npc_fruit_feeding(monkeypatch):
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    game.map.plants = [[[] for _ in range(6)] for _ in range(6)]
+    npc = NPCAnimal(id=2, name="Nanosaurus", sex=None, energy=50.0, weight=5.0)
+    game.map.animals[0][0] = [npc]
+    game.map.plants[0][0] = [Plant(name="Fruits", weight=20.0)]
+    game._update_npcs()
+    assert npc.energy > 50.0
+    assert npc.weight > 5.0
+    assert game.map.plants[0][0][0].weight < 20.0
+
+
 def test_npc_initial_state():
     random.seed(0)
     game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)


### PR DESCRIPTION
## Summary
- allow fruits as a diet option
- update NPC feeding logic to consume fruits
- test that herbivores eat fruits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e68752f0832eaffe209472422750