### PR TITLE
Restrict herbivore plant diet

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -637,7 +637,12 @@ class Game:
                             continue
 
                     if plants and any(d in diet for d in (Diet.FERNS, Diet.CYCADS, Diet.CONIFERS, Diet.FRUITS)):
-                        options = [p for p in plants if p.name.lower() in ("ferns", "cycads", "conifers", "fruits")]
+                        allowed_plants = {
+                            d.value
+                            for d in diet
+                            if d in (Diet.FERNS, Diet.CYCADS, Diet.CONIFERS, Diet.FRUITS)
+                        }
+                        options = [p for p in plants if p.name.lower() in allowed_plants]
                         if options:
                             chosen = max(options, key=lambda p: p.weight)
                             eaten = self._npc_consume_plant(npc, chosen, stats)

--- a/tests/test_plants.py
+++ b/tests/test_plants.py
@@ -77,6 +77,24 @@ def test_npc_fruit_feeding(monkeypatch):
     assert game.map.plants[0][0][0].weight < 20.0
 
 
+def test_herbivore_eats_only_diet_plants(monkeypatch):
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    game.map.plants = [[[] for _ in range(6)] for _ in range(6)]
+    npc = NPCAnimal(id=3, name="Stegosaurus", sex=None, energy=50.0, weight=10.0)
+    game.map.animals[0][0] = [npc]
+    game.map.plants[0][0] = [
+        Plant(name="Ferns", weight=20.0),
+        Plant(name="Fruits", weight=20.0),
+    ]
+    game._update_npcs()
+    ferns = next(p for p in game.map.plants[0][0] if p.name == "Ferns")
+    fruits = next(p for p in game.map.plants[0][0] if p.name == "Fruits")
+    assert ferns.weight < 20.0
+    assert fruits.weight == 20.0
+
+
 def test_npc_initial_state():
     random.seed(0)
     game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)


### PR DESCRIPTION
## Summary
- herbivores only eat plant types from their diet
- test that herbivores ignore plants outside their diet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e8e96b00832ebb106a26498149dd