### PR TITLE
Fix carcasses being able to attack

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -189,6 +189,8 @@ class Game:
             if entry.eggs or entry.in_pack or entry.npc is None:
                 continue
             npc = entry.npc
+            if not npc.alive:
+                continue
             stats = DINO_STATS.get(npc.name, {})
             if not stats.get("aggressive"):
                 continue

--- a/tests/test_carcass_attack.py
+++ b/tests/test_carcass_attack.py
@@ -1,0 +1,18 @@
+import os, sys, random
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import dinosurvival.game as game_mod
+from dinosurvival.dinosaur import NPCAnimal
+from dinosurvival.settings import MORRISON
+
+
+def test_carcass_cannot_attack():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    carcass = NPCAnimal(id=1, name="Allosaurus", sex=None, alive=False, weight=100.0)
+    game.map.animals[game.y][game.x] = [carcass]
+    game._generate_encounters()
+    random.seed(1)
+    attack = game._aggressive_attack_check()
+    assert attack is None
+


### PR DESCRIPTION
## Summary
- prevent aggressive attack check from considering dead dinosaurs
- add regression test to ensure carcasses cannot attack

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f0001b1c832ea3e47d9d4924c335