### PR TITLE
Fix spawn scaling in Hell Creek

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -207,16 +207,17 @@ class Game:
             old_count = stats.get("initial_spawn_multiplier", 0)
             spawn_count = spawn_counts.get(name, 0)
             spawn_tiles = lake_tiles if not stats.get("can_walk", True) else land_tiles
-            if not spawn_tiles or old_count <= 0:
+            loop_count = max(old_count, spawn_count)
+            if not spawn_tiles or loop_count <= 0:
                 # still consume random numbers to keep sequence stable
-                for _ in range(old_count):
+                for _ in range(loop_count):
                     random.choice(spawn_tiles)
                     if name == self.player.name:
                         random.choice(["M", "F"])
                     if stats.get("can_be_juvenile", True):
                         random.uniform(3.0, stats.get("adult_weight", 0.0))
                 continue
-            for i in range(old_count):
+            for i in range(loop_count):
                 x, y = random.choice(spawn_tiles)
                 sex: str | None = None
                 if name == self.player.name:

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -1,0 +1,21 @@
+import random
+import dinosurvival.game as game_mod
+from dinosurvival.settings import HELL_CREEK
+
+
+def test_hell_creek_population_scaling():
+    random.seed(0)
+    game = game_mod.Game(HELL_CREEK, "Tyrannosaurus", width=6, height=6)
+    counts = {}
+    for row in game.map.animals:
+        for cell in row:
+            for npc in cell:
+                counts[npc.name] = counts.get(npc.name, 0) + 1
+    multipliers = {
+        name: stats.get("initial_spawn_multiplier", 0)
+        for name, stats in game_mod.DINO_STATS.items()
+        if HELL_CREEK.formation in stats.get("formations", [])
+    }
+    total = sum(counts.get(name, 0) for name in multipliers)
+    assert total == 100
+    assert any(counts.get(name, 0) != multipliers[name] for name in multipliers)


### PR DESCRIPTION
## Summary
- fix NPC spawn logic so spawn counts scale to 100 animals
- add regression test for Hell Creek spawn scaling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6bf4ef4c832e9cb7d9cd175ce357