### PR TITLE
Add critter spawning and global constants

### DIFF
--- a/dinosurvival/constants.ini
+++ b/dinosurvival/constants.ini
@@ -1,0 +1,6 @@
+[DEFAULT]
+walking_energy_drain_multiplier = 1.3
+hatchling_weight_divisor = 1000
+hatchling_fierceness_divisor = 1000
+hatchling_speed_multiplier = 3
+hatchling_energy_drain_divisor = 2

--- a/dinosurvival/critter_stats_hell_creek.yaml
+++ b/dinosurvival/critter_stats_hell_creek.yaml
@@ -1,0 +1,17 @@
+{
+  "Centipede": {
+    "name": "Centipede",
+    "image": "assets/dinosaurs/centipede.png",
+    "can_be_juvenile": false,
+    "aggressive": false,
+    "adult_weight": 1.0,
+    "adult_fierceness": 0.0,
+    "adult_speed": 55,
+    "health_regen": 2.5,
+    "aquatic_boost": 0.0,
+    "preferred_biomes": ["forest"],
+    "can_walk": true,
+    "spawned_per_turn": 1,
+    "maximum_individuals": 20
+  }
+}

--- a/dinosurvival/dino_stats_hell_creek.yaml
+++ b/dinosurvival/dino_stats_hell_creek.yaml
@@ -1,9 +1,6 @@
 {
   "Acheroraptor": {
     "name": "Acheroraptor",
-    "formations": [
-      "Hell Creek"
-    ],
     "image": "assets/dinosaurs/acheroraptor.png",
     "can_be_juvenile": true,
     "aggressive": true,
@@ -16,7 +13,6 @@
     "adult_speed": 100,
     "adult_energy_drain": 4.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.2,
     "aquatic_boost": 0.0,
@@ -31,9 +27,6 @@
   },
   "Edmontosaurus": {
     "name": "Edmontosaurus",
-    "formations": [
-      "Hell Creek"
-    ],
     "image": "assets/dinosaurs/edmontosaurus.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -47,7 +40,6 @@
     "adult_speed": 25,
     "adult_energy_drain": 2.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -62,9 +54,6 @@
   },
   "Leptoceratops": {
     "name": "Leptoceratops",
-    "formations": [
-      "Hell Creek"
-    ],
     "image": "assets/dinosaurs/leptoceratops.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -77,7 +66,6 @@
     "adult_speed": 40,
     "adult_energy_drain": 4.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -92,9 +80,6 @@
   },
   "Pachycephalosaurus": {
     "name": "Pachycephalosaurus",
-    "formations": [
-      "Hell Creek"
-    ],
     "image": "assets/dinosaurs/pachycephalosaurus.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -108,7 +93,6 @@
     "adult_speed": 40,
     "adult_energy_drain": 4.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -123,9 +107,6 @@
   },
   "Thescelosaurus": {
     "name": "Thescelosaurus",
-    "formations": [
-      "Hell Creek"
-    ],
     "image": "assets/dinosaurs/thescelosaurus.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -138,7 +119,6 @@
     "adult_speed": 50,
     "adult_energy_drain": 3.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -153,9 +133,6 @@
   },
   "Triceratops": {
     "name": "Triceratops",
-    "formations": [
-      "Hell Creek"
-    ],
     "image": "assets/dinosaurs/triceratops.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -168,7 +145,6 @@
     "adult_speed": 18,
     "adult_energy_drain": 2.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -183,9 +159,6 @@
   },
   "Tyrannosaurus": {
     "name": "Tyrannosaurus",
-    "formations": [
-      "Hell Creek"
-    ],
     "image": "assets/dinosaurs/tyrannosaurus.png",
     "can_be_juvenile": true,
     "aggressive": true,
@@ -198,7 +171,6 @@
     "adult_speed": 35,
     "adult_energy_drain": 4.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.2,
     "aquatic_boost": 0.0,

--- a/dinosurvival/dino_stats_morrison.yaml
+++ b/dinosurvival/dino_stats_morrison.yaml
@@ -1,9 +1,6 @@
 {
   "Alcovasaurus": {
     "name": "Alcovasaurus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/alcovasaurus.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -17,7 +14,6 @@
     "adult_speed": 20,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.0,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -32,9 +28,6 @@
   },
   "Allosaurus": {
     "name": "Allosaurus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/allosaurus.png",
     "can_be_juvenile": true,
     "aggressive": true,
@@ -47,7 +40,6 @@
     "adult_speed": 30,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -62,9 +54,6 @@
   },
   "Amphicotylus": {
     "name": "Amphicotylus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/amphicotylus.png",
     "can_be_juvenile": true,
     "aggressive": true,
@@ -77,7 +66,6 @@
     "adult_speed": 50,
     "adult_energy_drain": 1.5,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.0,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -91,9 +79,6 @@
   },
   "Brachiosaurus": {
     "name": "Brachiosaurus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/brachiosaurus.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -106,7 +91,6 @@
     "adult_speed": 11,
     "adult_energy_drain": 1.2,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -121,9 +105,6 @@
   },
   "Camarasaurus": {
     "name": "Camarasaurus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/camarasaurus.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -137,7 +118,6 @@
     "adult_speed": 15,
     "adult_energy_drain": 1.6,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -152,9 +132,6 @@
   },
   "Camptosaurus": {
     "name": "Camptosaurus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/camptosaurus.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -167,7 +144,6 @@
     "adult_speed": 35,
     "adult_energy_drain": 3.6,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -182,9 +158,6 @@
   "Centipede": {
     "name": "Centipede",
     "image": "assets/dinosaurs/centipede.png",
-    "formations": [
-      "Morrison"
-    ],
     "can_be_juvenile": false,
     "aggressive": false,
     "forms_packs": false,
@@ -196,7 +169,6 @@
     "adult_speed": 55,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -211,9 +183,6 @@
   "Ceratodus": {
     "name": "Ceratodus",
     "image": "assets/dinosaurs/ceratodus.png",
-    "formations": [
-      "Morrison"
-    ],
     "can_be_juvenile": false,
     "aggressive": false,
     "forms_packs": false,
@@ -225,7 +194,6 @@
     "adult_speed": 55,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -239,9 +207,6 @@
   },
   "Ceratosaurus": {
     "name": "Ceratosaurus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/ceratosaurus.png",
     "can_be_juvenile": true,
     "aggressive": true,
@@ -254,7 +219,6 @@
     "adult_speed": 45,
     "adult_energy_drain": 4,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 40.0,
@@ -269,9 +233,6 @@
   },
   "Diplodocus": {
     "name": "Diplodocus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/diplodocus.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -285,7 +246,6 @@
     "adult_speed": 12,
     "adult_energy_drain": 1.2,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -300,9 +260,6 @@
   "Dragonfly": {
     "name": "Dragonfly",
     "image": "assets/dinosaurs/dragonfly.png",
-    "formations": [
-      "Morrison"
-    ],
     "can_be_juvenile": false,
     "aggressive": false,
     "forms_packs": false,
@@ -314,7 +271,6 @@
     "adult_speed": 75,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -328,9 +284,6 @@
   },
   "Dryosaurus": {
     "name": "Dryosaurus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/dryosaurus.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -344,7 +297,6 @@
     "adult_speed": 40,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -360,9 +312,6 @@
   "Frog": {
     "name": "Frog",
     "image": "assets/dinosaurs/frog.png",
-    "formations": [
-      "Morrison"
-    ],
     "can_be_juvenile": false,
     "aggressive": false,
     "forms_packs": false,
@@ -374,7 +323,6 @@
     "adult_speed": 45,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -388,9 +336,6 @@
   },
   "Fruitadens": {
     "name": "Fruitadens",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/fruitadens.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -404,7 +349,6 @@
     "adult_speed": 60,
     "adult_energy_drain": 8.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -418,9 +362,6 @@
   },
   "Gargoyleosaurus": {
     "name": "Gargoyleosaurus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/gargoyleosaurus.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -433,7 +374,6 @@
     "adult_speed": 20,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -447,9 +387,6 @@
   },
   "Glyptops": {
     "name": "Glyptops",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/glyptops.png",
     "can_be_juvenile": false,
     "aggressive": false,
@@ -463,7 +400,6 @@
     "adult_speed": 45,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.0,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -478,9 +414,6 @@
   "Lizard": {
     "name": "Lizard",
     "image": "assets/dinosaurs/lizard.png",
-    "formations": [
-      "Morrison"
-    ],
     "can_be_juvenile": false,
     "aggressive": false,
     "forms_packs": false,
@@ -492,7 +425,6 @@
     "adult_speed": 55,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -507,9 +439,6 @@
   "Morrolepis": {
     "name": "Morrolepis",
     "image": "assets/dinosaurs/morrolepis.png",
-    "formations": [
-      "Morrison"
-    ],
     "can_be_juvenile": false,
     "aggressive": false,
     "forms_packs": false,
@@ -521,7 +450,6 @@
     "adult_speed": 65,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -535,9 +463,6 @@
   },
   "Mymoorapelta": {
     "name": "Mymoorapelta",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/mymoorapelta.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -550,7 +475,6 @@
     "adult_speed": 22,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -565,9 +489,6 @@
   },
   "Nanosaurus": {
     "name": "Nanosaurus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/nanosaurus.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -580,7 +501,6 @@
     "adult_speed": 50,
     "adult_energy_drain": 7.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -594,9 +514,6 @@
   },
   "Ornitholestes": {
     "name": "Ornitholestes",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/ornitholestes.png",
     "can_be_juvenile": true,
     "aggressive": true,
@@ -609,7 +526,6 @@
     "adult_speed": 50,
     "adult_energy_drain": 4.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -624,9 +540,6 @@
   "Scorpion": {
     "name": "Scorpion",
     "image": "assets/dinosaurs/scorpion.png",
-    "formations": [
-      "Morrison"
-    ],
     "can_be_juvenile": false,
     "aggressive": true,
     "forms_packs": false,
@@ -638,7 +551,6 @@
     "adult_speed": 65,
     "adult_energy_drain": 5.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -652,9 +564,6 @@
   },
   "Stegosaurus": {
     "name": "Stegosaurus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/stegosaurus.png",
     "can_be_juvenile": true,
     "aggressive": false,
@@ -668,7 +577,6 @@
     "adult_speed": 20,
     "adult_energy_drain": 3.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.3,
     "health_regen": 2.5,
     "hydration_drain": 2.5,
     "aquatic_boost": 0.0,
@@ -684,9 +592,6 @@
   },
   "Torvosaurus": {
     "name": "Torvosaurus",
-    "formations": [
-      "Morrison"
-    ],
     "image": "assets/dinosaurs/torvosaurus.png",
     "can_be_juvenile": true,
     "aggressive": true,
@@ -699,7 +604,6 @@
     "adult_speed": 35,
     "adult_energy_drain": 4.0,
     "growth_rate": 0.35,
-    "walking_energy_drain_multiplier": 1.5,
     "health_regen": 2.5,
     "hydration_drain": 2.2,
     "aquatic_boost": 0.0,

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -14,7 +14,6 @@ def test_hell_creek_population_scaling():
     multipliers = {
         name: stats.get("initial_spawn_multiplier", 0)
         for name, stats in game_mod.DINO_STATS.items()
-        if HELL_CREEK.formation in stats.get("formations", [])
     }
     total = sum(counts.get(name, 0) for name in multipliers)
     assert total == 100


### PR DESCRIPTION
## Summary
- centralize constants in a new `constants.ini`
- strip `formations` and `walking_energy_drain_multiplier` from dino stat YAMLs
- add `critter_stats_hell_creek.yaml` with centipede definition
- spawn critters each turn and keep their energy at 100%
- update tests for new stats loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a96e6651c832ea7cccc4032e90f6f