### PR TITLE
Implement plant weight accumulation

### DIFF
--- a/dinosurvival/map.py
+++ b/dinosurvival/map.py
@@ -160,17 +160,23 @@ class Map:
         for y in range(self.height):
             for x in range(self.width):
                 cell_plants = self.plants[y][x]
-                if len(cell_plants) >= 2:
-                    continue
                 terrain = self.terrain_at(x, y).name
                 for name, stats in plant_stats.items():
                     if formation not in stats.formations:
                         continue
                     chance = stats.growth_chance.get(terrain, 0)
-                    if random.random() < chance:
+                    if random.random() >= chance:
+                        continue
+
+                    existing = next((p for p in cell_plants if p.name == name), None)
+                    if existing is not None:
+                        existing.weight = min(
+                            existing.weight + stats.weight, stats.weight * 10
+                        )
+                    elif len(cell_plants) < 2:
                         cell_plants.append(Plant(name=name, weight=stats.weight))
-                        if len(cell_plants) >= 2:
-                            break
+                    if len(cell_plants) >= 2:
+                        break
 
     def remove_animal(
         self,

--- a/tests/test_plants.py
+++ b/tests/test_plants.py
@@ -48,6 +48,26 @@ def test_max_two_plants_per_tile(monkeypatch):
     assert len(game.map.plants[0][0]) <= 2
 
 
+def test_plant_weight_accumulates(monkeypatch):
+    custom_stats = {
+        "TP": PlantStats(
+            name="TP",
+            formations=["Morrison"],
+            image="",
+            weight=1.0,
+            growth_chance={terrain: 1.0 for terrain in MORRISON.terrains},
+        )
+    }
+    monkeypatch.setattr(game_mod, "PLANT_STATS", custom_stats)
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    for _ in range(15):
+        game.turn("stay")
+    cell_plants = game.map.plants[0][0]
+    assert len(cell_plants) == 1
+    assert cell_plants[0].weight == 10.0
+
+
 def test_npc_state_and_feeding(monkeypatch):
     random.seed(0)
     game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)


### PR DESCRIPTION
## Summary
- aggregate plant weight instead of duplicating plants in a cell
- cap plant weight at 10× its base stats weight
- test that plant weight accumulation works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac7b66408832ebfe5894f606375c3