### PR TITLE
Track NPC hunting history

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -382,6 +382,15 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         tk.Label(win, text=f"Energy: {npc.energy:.0f}%", font=("Helvetica", 12), anchor="w").pack(anchor="w")
         sep = tk.Frame(win, height=2, bd=1, relief="sunken")
         sep.pack(fill="x", pady=5)
+        if npc.hunts:
+            tk.Label(win, text="Successful Hunts:", font=("Helvetica", 12), anchor="w").pack(anchor="w")
+            for prey, count in sorted(npc.hunts.items()):
+                tk.Label(win, text=f"  {prey}: {count}", font=("Helvetica", 12), anchor="w").pack(anchor="w")
+        else:
+            tk.Label(win, text="Successful Hunts: None", font=("Helvetica", 12), anchor="w").pack(anchor="w")
+        tk.Label(win, text=f"Egg clusters eaten: {npc.egg_clusters_eaten}", font=("Helvetica", 12), anchor="w").pack(anchor="w")
+        sep = tk.Frame(win, height=2, bd=1, relief="sunken")
+        sep.pack(fill="x", pady=5)
         tk.Label(
             win,
             text=f"Weight: {npc.weight:.1f}/{stats.get('adult_weight', 0)}",

--- a/dinosurvival/dinosaur.py
+++ b/dinosurvival/dinosaur.py
@@ -61,5 +61,7 @@ class NPCAnimal:
     speed: float = 0.0
     next_move: str = "None"
     turns_until_lay_eggs: int = 0
+    hunts: dict[str, int] = field(default_factory=dict)
+    egg_clusters_eaten: int = 0
 
 

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -581,6 +581,8 @@ class Game:
         remaining = eat_amount - weight_used
         self._npc_apply_growth(npc, remaining, stats)
         eggs.weight -= eat_amount
+        if eat_amount > 0:
+            npc.egg_clusters_eaten += 1
         return eat_amount
 
     def _can_player_lay_eggs(self) -> bool:
@@ -936,6 +938,7 @@ class Game:
                                 target.age = -1
                                 target.fierceness = 0.0
                                 target.speed = 0.0
+                                npc.hunts[target.name] = npc.hunts.get(target.name, 0) + 1
                                 eaten = self._npc_consume_meat(npc, target, stats)
                                 if x == self.x and y == self.y:
                                     messages.append(


### PR DESCRIPTION
## Summary
- extend `NPCAnimal` dataclass to store hunt counts and egg clusters eaten
- show NPC hunting history in the stats window
- increment egg clusters eaten and successful hunts during NPC actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad2d3a1c4832e9640daaad37fa827