### PR TITLE
Fix dead NPC movement

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -730,6 +730,9 @@ class Game:
                     d = npc.next_move
                     if not d or d == "None":
                         continue
+                    if not npc.alive:
+                        npc.next_move = "None"
+                        continue
                     dx, dy = directions.get(d, (0, 0))
                     nx, ny = x + dx, y + dy
                     if 0 <= nx < self.map.width and 0 <= ny < self.map.height:

--- a/tests/test_dead_movement.py
+++ b/tests/test_dead_movement.py
@@ -1,0 +1,15 @@
+import dinosurvival.game as game_mod
+from dinosurvival.dinosaur import NPCAnimal
+from dinosurvival.settings import MORRISON
+
+
+def test_dead_npc_does_not_move():
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    npc = NPCAnimal(id=1, name="Stegosaurus", sex=None, weight=10.0)
+    game.map.animals[0][0] = [npc]
+    npc.next_move = "Right"
+    npc.alive = False
+    game._move_npcs()
+    assert npc in game.map.animals[0][0]
+    assert npc.next_move == "None"


### PR DESCRIPTION
## Summary
- stop NPCs from moving once dead
- add regression test for corpse movement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aedcde88c832ebf74bc54a012f674