### PR TITLE
Remove egg cluster after consumption

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -570,9 +570,8 @@ class Game:
 
     def _npc_consume_eggs(self, npc: NPCAnimal, eggs: EggCluster, stats: dict) -> float:
         energy_needed = 100.0 - npc.energy
-        weight_for_energy = energy_needed * npc.weight / 1000
         growth_target = self._npc_max_growth_gain(npc.weight, stats)
-        eat_amount = min(eggs.weight, weight_for_energy + growth_target)
+        eat_amount = eggs.weight
 
         energy_gain_possible = 1000 * eat_amount / max(npc.weight, 0.1)
         actual_energy_gain = min(energy_needed, energy_gain_possible)
@@ -580,7 +579,7 @@ class Game:
         weight_used = actual_energy_gain * npc.weight / 1000
         remaining = eat_amount - weight_used
         self._npc_apply_growth(npc, remaining, stats)
-        eggs.weight -= eat_amount
+        eggs.weight = 0
         if eat_amount > 0:
             npc.egg_clusters_eaten += 1
         return eat_amount
@@ -888,8 +887,7 @@ class Game:
                                     messages.append(
                                         f"The {self._npc_label(npc)} eats {eaten:.1f}kg of eggs."
                                     )
-                                if egg.weight <= 0:
-                                    egg_clusters.remove(egg)
+                                egg_clusters.remove(egg)
                                 found_food = True
                                 npc.next_move = "None"
                                 continue

--- a/tests/test_egg_consumption.py
+++ b/tests/test_egg_consumption.py
@@ -1,0 +1,28 @@
+import random
+import dinosurvival.game as game_mod
+from dinosurvival.dinosaur import NPCAnimal
+from dinosurvival.map import EggCluster
+from dinosurvival.settings import MORRISON
+
+
+def test_npc_egg_cluster_removed_after_eating():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    game.map.eggs = [[[] for _ in range(6)] for _ in range(6)]
+    npc = NPCAnimal(id=1, name="Ceratosaurus", sex=None, energy=50.0, weight=10.0)
+    game.map.animals[0][0] = [npc]
+    game.map.eggs[0][0] = [EggCluster(species="Stegosaurus", number=1, weight=1.0, turns_until_hatch=5)]
+    game._update_npcs()
+    assert not game.map.eggs[0][0]
+    assert npc.egg_clusters_eaten == 1
+
+
+def test_player_collects_eggs_removes_cluster():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    game.map.eggs = [[[] for _ in range(6)] for _ in range(6)]
+    game.map.eggs[game.y][game.x] = [EggCluster(species="Stegosaurus", number=2, weight=2.0, turns_until_hatch=5)]
+    game.collect_eggs()
+    assert not game.map.eggs[game.y][game.x]


### PR DESCRIPTION
## Summary
- consume entire egg cluster in `_npc_consume_eggs`
- always remove egg cluster after NPC eats
- add tests verifying egg clusters disappear when eaten

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c275079dc832eb616c0d524b1738e