### PR TITLE
Add threaten action

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -503,6 +503,13 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     move_buttons["drink"] = tk.Button(
         btn_container, text="Drink", width=12, height=2, command=lambda: perform("drink")
     )
+    move_buttons["threaten"] = tk.Button(
+        btn_container,
+        text="Threaten",
+        width=12,
+        height=2,
+        command=lambda: do_threaten(),
+    )
 
     move_buttons["north"].grid(row=0, column=1)
     move_buttons["drink"].grid(row=0, column=2)
@@ -511,6 +518,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     move_buttons["stay"].grid(row=1, column=1)
     move_buttons["east"].grid(row=1, column=2)
     move_buttons["south"].grid(row=2, column=1)
+    move_buttons["threaten"].grid(row=2, column=2)
 
     # Encounter display in the center right
     encounter_frame = tk.Frame(main, width=500)
@@ -650,6 +658,24 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         update_stats()
         update_biome()
         update_map()
+        update_encounters()
+        update_plants()
+        if "Game Over" in result:
+            for b in move_buttons.values():
+                b.config(state="disabled")
+            show_final_stats("Game Over", "You have perished!")
+        if game.won:
+            for b in move_buttons.values():
+                b.config(state="disabled")
+            show_final_stats("Victory", "Congratulations! Your lineage lives on!")
+
+    def do_threaten() -> None:
+        result = game.threaten()
+        append_output(result)
+        update_biome()
+        update_stats()
+        update_drink_button()
+        update_lay_button()
         update_encounters()
         update_plants()
         if "Game Over" in result:

--- a/tests/test_threaten.py
+++ b/tests/test_threaten.py
@@ -1,0 +1,35 @@
+import random
+import dinosurvival.game as game_mod
+from dinosurvival.dinosaur import NPCAnimal
+from dinosurvival.settings import MORRISON
+
+
+def test_threaten_scatter():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    game.x = 3
+    game.y = 3
+    npc1 = NPCAnimal(id=1, name="Stegosaurus", sex=None, weight=1.0)
+    npc2 = NPCAnimal(id=2, name="Stegosaurus", sex=None, weight=1.0)
+    game.map.animals[3][3] = [npc1, npc2]
+    base = game._base_energy_drain()
+    game.player.energy = 100.0
+    game.threaten()
+    assert game.player.energy == 100.0 - base * 2
+    assert npc1 not in game.map.animals[3][3]
+    assert npc2 not in game.map.animals[3][3]
+
+
+def test_threaten_killed_by_stronger():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    game.x = 2
+    game.y = 2
+    strong = NPCAnimal(id=1, name="Allosaurus", sex=None, weight=3000.0)
+    game.map.animals[2][2] = [strong]
+    game.threaten()
+    assert game.player.health == 0
+
+


### PR DESCRIPTION
## Summary
- add a Threaten player ability that scatters weaker animals or results in death if a stronger animal is present
- use additional energy when threatening
- expose Threaten as a new button in the GUI
- test the new action

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c30ef39cc832e9c486fe17704ac66