### PR TITLE
Incorporate health into fierceness calculations

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -755,7 +755,10 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
             disp_name = f"{npc.name} ({npc.id})"
             disp_name = f"{disp_name} W:{npc.weight:.1f}kg"
 
-            target_f = game._stat_from_weight(npc.weight, stats, "hatchling_fierceness", "adult_fierceness")
+            target_f = game._stat_from_weight(
+                npc.weight, stats, "hatchling_fierceness", "adult_fierceness"
+            )
+            target_f *= npc.health / 100.0
             target_s = game._stat_from_weight(npc.weight, stats, "hatchling_speed", "adult_speed")
             rel_f = target_f / player_f
             rel_s = target_s / player_s
@@ -930,7 +933,8 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
                 f"{game.player.adult_weight:.0f}kg ({pct:.1f}%)"
             )
         )
-        fierce_label.config(text=f"Fierceness: {game.player.fierceness:.1f}")
+        adj_f = game.player.fierceness * (game.player.health / 100.0)
+        fierce_label.config(text=f"Fierceness: {adj_f:.1f}")
         speed_label.config(text=f"Speed: {game.player.speed:.1f}")
         desc_label.config(
             text=f"Alive descendants: {game.descendant_count()}"

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -342,6 +342,7 @@ class Game:
                 "hatchling_fierceness",
                 "adult_fierceness",
             )
+            target_f *= npc.health / 100.0
             rel_f = target_f / player_f
             if rel_f > 2.0 and random.random() < 0.5:
                 self.player.health = 0
@@ -358,7 +359,7 @@ class Game:
         )
 
     def effective_fierceness(self) -> float:
-        total = self.player.fierceness
+        total = self.player.fierceness * (self.player.health / 100.0)
         stats = DINO_STATS.get(self.player.name, {})
         for j in self.pack:
             if j:
@@ -660,6 +661,7 @@ class Game:
             npc_f = self._stat_from_weight(
                 npc.weight, stats, "hatchling_fierceness", "adult_fierceness"
             )
+            npc_f *= npc.health / 100.0
             if npc_f > player_f:
                 stronger.append(npc)
             else:
@@ -1002,13 +1004,19 @@ class Game:
 
                     if Diet.MEAT in diet:
                         npc_speed = self._stat_from_weight(npc.weight, stats, "hatchling_speed", "adult_speed")
-                        npc_f = self._stat_from_weight(npc.weight, stats, "hatchling_fierceness", "adult_fierceness")
+                        npc_f = self._stat_from_weight(
+                            npc.weight, stats, "hatchling_fierceness", "adult_fierceness"
+                        )
+                        npc_f *= npc.health / 100.0
                         potential = []
                         for other in animals:
                             if other is npc or not other.alive:
                                 continue
                             o_stats = DINO_STATS.get(other.name, {})
-                            o_f = self._stat_from_weight(other.weight, o_stats, "hatchling_fierceness", "adult_fierceness")
+                            o_f = self._stat_from_weight(
+                                other.weight, o_stats, "hatchling_fierceness", "adult_fierceness"
+                            )
+                            o_f *= other.health / 100.0
                             if o_f >= npc_f:
                                 continue
                             rel_f = o_f / max(npc_f, 0.1)
@@ -1097,7 +1105,10 @@ class Game:
                 self._stat_from_weight(target.weight, stats, "hatchling_speed", "adult_speed"),
                 0.1,
             )
-            target_f = self._stat_from_weight(target.weight, stats, "hatchling_fierceness", "adult_fierceness")
+            target_f = self._stat_from_weight(
+                target.weight, stats, "hatchling_fierceness", "adult_fierceness"
+            )
+            target_f *= target.health / 100.0
         else:
             target_speed = 0.0
             target_f = 0.0

--- a/tests/test_fierceness_health.py
+++ b/tests/test_fierceness_health.py
@@ -1,0 +1,18 @@
+import dinosurvival.game as game_mod
+from dinosurvival.settings import MORRISON
+
+
+def test_effective_fierceness_uses_health():
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.player.weight = game.player.adult_weight
+    game.player.fierceness = game.player.adult_fierceness
+    game.player.health = 50.0
+    assert game.effective_fierceness() == game.player.adult_fierceness * 0.5
+
+
+def test_aggressive_attack_uses_health():
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    npc = game_mod.NPCAnimal(id=1, name="Allosaurus", sex=None, weight=3000.0, health=0.1)
+    game.current_encounters = [game_mod.EncounterEntry(npc=npc)]
+    assert game._aggressive_attack_check() is None
+


### PR DESCRIPTION
## Summary
- factor health percentage into player effective fierceness
- scale NPC fierceness with their current health for aggression checks, threatening and NPC battles
- show health-adjusted fierceness in the encounter UI and player stats panel
- add tests covering the new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c637eec64832ea18b0e90a135039c