### PR TITLE
Allow unlimited plant types per cell

### DIFF
--- a/dinosurvival/map.py
+++ b/dinosurvival/map.py
@@ -174,10 +174,8 @@ class Map:
                         existing.weight = min(
                             existing.weight + stats.weight, stats.weight * 10
                         )
-                    elif len(cell_plants) < 2:
+                    else:
                         cell_plants.append(Plant(name=name, weight=stats.weight))
-                    if len(cell_plants) >= 2:
-                        break
 
     def remove_animal(
         self,

--- a/tests/test_plants.py
+++ b/tests/test_plants.py
@@ -30,22 +30,25 @@ def test_plants_generated_and_encounters(monkeypatch):
     assert game.current_plants[0].name == "TestPlant"
 
 
-def test_max_two_plants_per_tile(monkeypatch):
+def test_all_plant_types_can_coexist(monkeypatch):
     custom_stats = {
-        "TP": PlantStats(
-            name="TP",
+        f"TP{i}": PlantStats(
+            name=f"TP{i}",
             formations=["Morrison"],
             image="",
             weight=1.0,
             growth_chance={terrain: 1.0 for terrain in MORRISON.terrains},
         )
+        for i in range(4)
     }
     monkeypatch.setattr(game_mod, "PLANT_STATS", custom_stats)
     random.seed(0)
     game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
-    for _ in range(5):
+    # Run a few turns to ensure growth occurs
+    for _ in range(3):
         game.turn("stay")
-    assert len(game.map.plants[0][0]) <= 2
+    names = {p.name for p in game.map.plants[0][0]}
+    assert names == set(custom_stats.keys())
 
 
 def test_plant_weight_accumulates(monkeypatch):


### PR DESCRIPTION
## Summary
- remove the two-plant limit when growing plants
- update tests to reflect unlimited plant types per tile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c799a6cdc832ea33680b57a43efb0