### PR TITLE
Add ambush ability for Tyrannosaurus

### DIFF
--- a/dinosurvival/dino_stats_hell_creek.yaml
+++ b/dinosurvival/dino_stats_hell_creek.yaml
@@ -220,6 +220,7 @@
     "diet": [
       "meat"
     ],
+    "abilities": ["ambush"],
     "adult_weight": 8000.0,
     "adult_fierceness": 8000.0,
     "adult_speed": 38,

--- a/dinosurvival/dinosaur.py
+++ b/dinosurvival/dinosaur.py
@@ -37,6 +37,8 @@ class DinosaurStats:
     mated: bool = False
     turns_until_lay_eggs: int = 0
     diet: list[Diet] = field(default_factory=list)
+    abilities: list[str] = field(default_factory=list)
+    ambush_streak: int = 0
 
     def is_exhausted(self) -> bool:
         return self.energy <= 0
@@ -64,5 +66,8 @@ class NPCAnimal:
     hunts: dict[str, int] = field(default_factory=dict)
     egg_clusters_eaten: int = 0
     is_descendant: bool = False
+    abilities: list[str] = field(default_factory=list)
+    ambush_streak: int = 0
+    last_action: str = "None"
 
 


### PR DESCRIPTION
## Summary
- support abilities in dinosaur data
- implement Ambush ability stacking for player and NPC Tyrannosaurs
- display effective speed with ambush bonuses
- show abilities on NPC stats window
- add ambush entry to Tyrannosaurus data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da12136e0832e8768d7cd202c4cf1