### PR TITLE
Implement burrow improvements and menu back button

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -83,8 +83,12 @@ def display_legacy_stats(parent: tk.Widget, formation: str, dname: str) -> None:
     tk.Button(win, text="Close", command=win.destroy).pack(pady=5)
 
 
-def choose_dinosaur_gui(root: tk.Tk, setting, on_select) -> None:
-    """Display a dinosaur selection menu inside an existing root window."""
+def choose_dinosaur_gui(root: tk.Tk, setting, on_select, on_back=None) -> None:
+    """Display a dinosaur selection menu inside an existing root window.
+
+    ``on_back`` can be provided to return to a previous menu instead of
+    closing the application.
+    """
 
     frame = tk.Frame(root)
     frame.pack(expand=True)
@@ -177,7 +181,10 @@ def choose_dinosaur_gui(root: tk.Tk, setting, on_select) -> None:
         tk.Button(row, text="Dinosaur Stats", command=lambda d=dino: show_legacy(d)).pack(side="left")
         row.pack(pady=5)
 
-    tk.Button(frame, text="Quit", width=20, height=2, command=root.destroy).pack(pady=10)
+    btn_row = tk.Frame(frame)
+    btn_row.pack(pady=10)
+    tk.Button(btn_row, text="Back", width=20, height=2, command=lambda: (frame.destroy(), on_back() if on_back else None)).pack(side="left", padx=5)
+    tk.Button(btn_row, text="Quit", width=20, height=2, command=root.destroy).pack(side="left", padx=5)
 
     # This function does not start a new main loop; the provided root must already
     # be running. The window will be destroyed when a dinosaur is chosen.
@@ -1143,7 +1150,7 @@ def launch_menu():
             selection["setting"] = setting
             selection["dino"] = dino
 
-        choose_dinosaur_gui(root, setting, on_select)
+        choose_dinosaur_gui(root, setting, on_select, on_back=show_start_menu)
 
     show_start_menu()
     root.mainloop()

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -419,6 +419,7 @@ class Game:
         self.turn_messages.extend(self._update_eggs())
         self.map.grow_plants(PLANT_STATS, self.setting.formation)
         self._spawn_critters()
+        self.map.refresh_burrows()
         if getattr(self.player, "turns_until_lay_eggs", 0) > 0:
             self.player.turns_until_lay_eggs -= 1
         self.player.hydration = max(

--- a/dinosurvival/map.py
+++ b/dinosurvival/map.py
@@ -174,6 +174,9 @@ class Map:
         return self.burrows[y][x] is not None
 
     def spawn_burrow(self, x: int, y: int, full: bool = True) -> None:
+        """Create a burrow on the specified cell if it is not a lake."""
+        if self.terrain_at(x, y).name == "lake":
+            return
         self.burrows[y][x] = Burrow(full=full)
 
     def get_burrow(self, x: int, y: int) -> Optional[Burrow]:
@@ -192,6 +195,16 @@ class Map:
             x, y = random.choice(land_tiles)
             land_tiles.remove((x, y))
             self.spawn_burrow(x, y, full=True)
+
+    def refresh_burrows(self, chance: float = 0.02) -> None:
+        """Randomly refill empty burrows based on a probability."""
+        for y in range(self.height):
+            for x in range(self.width):
+                burrow = self.burrows[y][x]
+                if burrow is not None and not burrow.full:
+                    if random.random() < chance:
+                        burrow.full = True
+                        burrow.progress = 0.0
 
     def grow_plants(self, plant_stats: dict[str, "PlantStats"], formation: str) -> None:
         for y in range(self.height):


### PR DESCRIPTION
## Summary
- prevent burrows from spawning on lake tiles
- allow empty burrows to refill with a 2% chance each turn
- call refresh_burrows at the start of each turn
- add a Back button to the dinosaur selection menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db66684a4832ebd2f32660efa15fe