### PR TITLE
Spawn critters at game start

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -158,7 +158,7 @@ class Game:
         ]
         self.next_npc_id = 1
         self._populate_animals()
-        self._spawn_critters()
+        self._spawn_critters(initial=True)
 
         # Pick a random starting location that is within two tiles of a lake but
         # not on a lake tile itself
@@ -275,8 +275,12 @@ class Game:
                     )
                     self.next_npc_id += 1
 
-    def _spawn_critters(self) -> None:
-        """Spawn critters based on per-turn rates and population caps."""
+    def _spawn_critters(self, *, initial: bool = False) -> None:
+        """Spawn critters based on per-turn rates and population caps.
+
+        If ``initial`` is True, spawn half of the maximum number of each
+        critter regardless of the per-turn spawn rate.
+        """
         if not CRITTER_STATS:
             return
 
@@ -299,8 +303,11 @@ class Game:
                         if npc.name == name:
                             count += 1
             available = max_individuals - count
-            spawn_count = round(random.gauss(avg_rate, 0.5))
-            spawn_count = max(0, spawn_count)
+            if initial:
+                spawn_count = max_individuals // 2
+            else:
+                spawn_count = round(random.gauss(avg_rate, 0.5))
+                spawn_count = max(0, spawn_count)
             to_spawn = min(spawn_count, max(0, available))
             spawn_tiles = lake_tiles if not stats.get("can_walk", True) else land_tiles
             for _ in range(to_spawn):

--- a/tests/test_initial_critter_spawn.py
+++ b/tests/test_initial_critter_spawn.py
@@ -1,0 +1,21 @@
+import random
+import dinosurvival.game as game_mod
+from dinosurvival.settings import MORRISON
+
+
+def test_initial_critter_spawn_and_placement():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    for name, stats in game_mod.CRITTER_STATS.items():
+        count = 0
+        for y in range(game.map.height):
+            for x in range(game.map.width):
+                for npc in game.map.animals[y][x]:
+                    if npc.name == name:
+                        count += 1
+                        terrain = game.map.terrain_at(x, y).name
+                        if stats.get("can_walk", True):
+                            assert terrain != "lake"
+                        else:
+                            assert terrain == "lake"
+        assert count == stats.get("maximum_individuals", 0) // 2

--- a/tests/test_overcrowding.py
+++ b/tests/test_overcrowding.py
@@ -23,6 +23,7 @@ def test_overcrowded_laying_moves():
         turns_until_lay_eggs=0,
     )
     game.map.animals[0][0].append(ready)
+    random.seed(0)
     game._update_npcs()
     assert not game.map.eggs[0][0]
     assert ready.next_move != "None"


### PR DESCRIPTION
## Summary
- spawn half of each critter species at game start
- place critters based on `can_walk`
- adjust overcrowding test for new RNG usage
- test that initial critters spawn correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db8557e70832eaa995b36a7c8fd60