### PR TITLE
Add digger ability and new Hell Creek dinos

### DIFF
--- a/dinosurvival/dino_stats_hell_creek.yaml
+++ b/dinosurvival/dino_stats_hell_creek.yaml
@@ -150,6 +150,9 @@
     "diet": [
       "meat"
     ],
+    "abilities": [
+      "digger"
+    ],
     "egg_laying_interval": 12,
     "forms_packs": false,
     "growth_rate": 0.35,

--- a/dinosurvival/settings.py
+++ b/dinosurvival/settings.py
@@ -42,6 +42,8 @@ HELL_CREEK = Setting(
     formation="Hell Creek",
     playable_dinos={
         "Tyrannosaurus": {"energy_threshold": 0, "growth_stages": 4},
+        "Acheroraptor": {"energy_threshold": 0, "growth_stages": 3},
+        "Pectinodon": {"energy_threshold": 0, "growth_stages": 3},
     },
     terrains={
         "badlands": Terrain("badlands", {"small_prey": 0.3, "large_prey": 0.7}),

--- a/tests/test_digger.py
+++ b/tests/test_digger.py
@@ -1,0 +1,37 @@
+import random
+import dinosurvival.game as game_mod
+from dinosurvival.dinosaur import NPCAnimal
+from dinosurvival.settings import HELL_CREEK
+
+
+def test_pectinodon_dig_burrow_one_turn():
+    random.seed(0)
+    game = game_mod.Game(HELL_CREEK, "Pectinodon", width=6, height=6)
+    game.map.spawn_burrow(game.x, game.y, full=True)
+    burrow = game.map.get_burrow(game.x, game.y)
+    assert burrow is not None and burrow.full
+    game.dig_burrow()
+    burrow = game.map.get_burrow(game.x, game.y)
+    assert burrow is not None and not burrow.full
+    assert burrow.progress == 0.0
+    found = any(npc.name == "Didelphodon" for npc in game.map.animals[game.y][game.x])
+    assert found
+
+
+def test_npc_digger_digs_burrow():
+    random.seed(0)
+    game = game_mod.Game(HELL_CREEK, "Tyrannosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    game.map.spawn_burrow(0, 0, full=True)
+    npc = NPCAnimal(id=1, name="Pectinodon", sex=None, energy=50.0, weight=10.0, abilities=["digger"])
+    game.map.animals[0][0] = [npc]
+    game._update_npcs()
+    burrow = game.map.get_burrow(0, 0)
+    assert burrow is not None and not burrow.full
+    found = any(n.name == "Didelphodon" for n in game.map.animals[0][0] if n is not npc)
+    assert found
+
+
+def test_hell_creek_playable_list():
+    assert "Pectinodon" in HELL_CREEK.playable_dinos
+    assert "Acheroraptor" in HELL_CREEK.playable_dinos


### PR DESCRIPTION
## Summary
- make Pectinodon and Acheroraptor playable in Hell Creek
- give Pectinodon the new `digger` ability
- digging finishes a burrow in one action for dinos with this ability
- NPCs with `digger` now dig burrows when hungry
- add tests for digging behaviour and playable dino list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dbdf8cfd4832ebad9b6a1aaa55bdc