### PR TITLE
Update map visibility and icons

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -920,24 +920,26 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
                     fill=color,
                     outline="black",
                 )
-                if revealed and game.map.has_nest(x, y):
+                if (
+                    revealed
+                    and game.map.has_nest(x, y)
+                    and abs(game.x - x) + abs(game.y - y) == 1
+                ):
+                    canvas.create_oval(
+                        tile_size / 2 - 2,
+                        tile_size / 2 - 4,
+                        tile_size / 2 + 2,
+                        tile_size / 2 + 4,
+                        fill="white",
+                        outline="white",
+                    )
+                if revealed and game.map.has_burrow(x, y):
                     canvas.create_oval(
                         tile_size / 2 - 3,
                         tile_size / 2 - 3,
                         tile_size / 2 + 3,
                         tile_size / 2 + 3,
                         fill="black",
-                        outline="black",
-                    )
-                if revealed and game.map.has_burrow(x, y):
-                    canvas.create_polygon(
-                        tile_size / 2,
-                        tile_size / 2 - 4,
-                        tile_size / 2 - 4,
-                        tile_size / 2 + 4,
-                        tile_size / 2 + 4,
-                        tile_size / 2 + 4,
-                        fill="brown",
                         outline="black",
                     )
                 if (x, y) == (game.x, game.y):

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -190,6 +190,7 @@ class Game:
             self.x = width // 2
             self.y = height // 2
         self.map.reveal(self.x, self.y)
+        self._reveal_cardinals(self.x, self.y)
         self._reveal_adjacent_mountains()
         self._energy_multiplier = 1.0
         self.current_encounters: list[EncounterEntry] = []
@@ -491,6 +492,13 @@ class Game:
         if regen and not message:
             self.player.health = min(100.0, self.player.health + regen)
         return message
+
+    def _reveal_cardinals(self, x: int, y: int) -> None:
+        """Reveal the four orthogonally adjacent tiles to ``(x, y)``."""
+        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < self.map.width and 0 <= ny < self.map.height:
+                self.map.reveal(nx, ny)
 
     def _reveal_adjacent_mountains(self) -> None:
         for dy in (-1, 0, 1):
@@ -1605,6 +1613,7 @@ class Game:
         ny = max(0, min(self.map.height - 1, self.y + dy))
         self.x, self.y = nx, ny
         self.map.reveal(self.x, self.y)
+        self._reveal_cardinals(self.x, self.y)
         if self.map.terrain_at(self.x, self.y).name == "mountain":
             self._reveal_surrounding(self.x, self.y)
 


### PR DESCRIPTION
## Summary
- reveal tiles adjacent to the player on movement and start
- display egg markers only when the player is adjacent
- update egg icon to white oval
- change burrow icon to black circle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685efad11350832e894a4320e87624f1