### PR TITLE
Update biome images and remove unused prey data

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -207,8 +207,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     biome_images: dict[str, tk.PhotoImage] = {}
 
 
-    for tname in game.setting.terrains.keys():
-        fname = f"{game.setting.formation.lower().replace(' ', '_')}_{tname}.png"
+    for tname, fname in game.setting.biome_images.items():
         path = os.path.join(assets_dir, fname)
         img = load_scaled_image(path, 400, 250)
         if img:

--- a/dinosurvival/settings.py
+++ b/dinosurvival/settings.py
@@ -9,6 +9,7 @@ class Setting:
     formation: str
     playable_dinos: Dict[str, Dict]
     terrains: Dict[str, Terrain]
+    biome_images: Dict[str, str]
     height_levels: Dict[str, float]
     humidity_levels: Dict[str, float]
     num_burrows: int = 0
@@ -24,14 +25,24 @@ MORRISON = Setting(
         "Ornitholestes": {"energy_threshold": 0, "growth_stages": 3},
     },
     terrains={
-        "desert": Terrain("desert", {"small_prey": 0.3, "large_prey": 0.7}),
-        "toxic_badlands": Terrain("toxic_badlands", {"small_prey": 0.3, "large_prey": 0.7}),
-        "plains": Terrain("plains", {"small_prey": 0.8, "large_prey": 0.2}),
-        "woodlands": Terrain("woodlands", {"small_prey": 0.6, "large_prey": 0.4}),
-        "forest": Terrain("forest", {"small_prey": 0.6, "large_prey": 0.4}),
-        "swamp": Terrain("swamp", {"small_prey": 0.7, "large_prey": 0.3}),
-        "lake": Terrain("lake", {"small_prey": 0.9, "large_prey": 0.1}),
-        "mountain": Terrain("mountain", {"small_prey": 0.4, "large_prey": 0.6}),
+        "desert": Terrain("desert", {}),
+        "toxic_badlands": Terrain("toxic_badlands", {}),
+        "plains": Terrain("plains", {}),
+        "woodlands": Terrain("woodlands", {}),
+        "forest": Terrain("forest", {}),
+        "swamp": Terrain("swamp", {}),
+        "lake": Terrain("lake", {}),
+        "mountain": Terrain("mountain", {}),
+    },
+    biome_images={
+        "desert": "desert.png",
+        "toxic_badlands": "badlands.png",
+        "plains": "plains.png",
+        "woodlands": "woodlands.png",
+        "forest": "forest.png",
+        "swamp": "swamp.png",
+        "lake": "lake.png",
+        "mountain": "mountain.png",
     },
     height_levels={"low": 0.3, "normal": 0.45, "mountain": 0.25},
     humidity_levels={"arid": 0.3, "normal": 0.4, "humid": 0.3},
@@ -47,14 +58,24 @@ HELL_CREEK = Setting(
         "Pectinodon": {"energy_threshold": 0, "growth_stages": 3},
     },
     terrains={
-        "desert": Terrain("desert", {"small_prey": 0.3, "large_prey": 0.7}),
-        "toxic_badlands": Terrain("toxic_badlands", {"small_prey": 0.3, "large_prey": 0.7}),
-        "plains": Terrain("plains", {"small_prey": 0.4, "large_prey": 0.6}),
-        "woodlands": Terrain("woodlands", {"small_prey": 0.6, "large_prey": 0.4}),
-        "forest": Terrain("forest", {"small_prey": 0.7, "large_prey": 0.3}),
-        "swamp": Terrain("swamp", {"small_prey": 0.7, "large_prey": 0.3}),
-        "lake": Terrain("lake", {"small_prey": 0.9, "large_prey": 0.1}),
-        "mountain": Terrain("mountain", {"small_prey": 0.4, "large_prey": 0.6}),
+        "desert": Terrain("desert", {}),
+        "toxic_badlands": Terrain("toxic_badlands", {}),
+        "plains": Terrain("plains", {}),
+        "woodlands": Terrain("woodlands", {}),
+        "forest": Terrain("forest", {}),
+        "swamp": Terrain("swamp", {}),
+        "lake": Terrain("lake", {}),
+        "mountain": Terrain("mountain", {}),
+    },
+    biome_images={
+        "desert": "desert.png",
+        "toxic_badlands": "badlands.png",
+        "plains": "plains.png",
+        "woodlands": "woodlands.png",
+        "forest": "forest.png",
+        "swamp": "swamp.png",
+        "lake": "lake.png",
+        "mountain": "mountain.png",
     },
     height_levels={"low": 0.3, "normal": 0.6, "mountain": 0.1},
     humidity_levels={"arid": 0.2, "normal": 0.5, "humid": 0.3},


### PR DESCRIPTION
## Summary
- remove legacy `small_prey`/`large_prey` spawn data
- add a `biome_images` field to `Setting` and map terrains to shared images
- load biome images based on settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0748de94832e8c6d0910bf9e33e6