### PR TITLE
Handle lava terrain effects

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -526,6 +526,9 @@ class Game:
     def _apply_terrain_effects(self) -> None:
         """Apply end-of-turn biome effects to the player and NPCs."""
         terrain = self.map.terrain_at(self.x, self.y).name
+        if terrain in ("lava", "volcano_erupting"):
+            self.player.health = 0.0
+            self.turn_messages.append("Game Over.")
         if terrain == "toxic_badlands":
             self.player.health = max(0.0, self.player.health - 20.0)
             msg = "You take 20% damage from toxic fumes."
@@ -535,7 +538,18 @@ class Game:
 
         for y in range(self.map.height):
             for x in range(self.map.width):
-                if self.map.terrain_at(x, y).name != "toxic_badlands":
+                tname = self.map.terrain_at(x, y).name
+                if tname in ("lava", "volcano_erupting"):
+                    for npc in self.map.animals[y][x]:
+                        npc.alive = False
+                        npc.age = -1
+                        npc.fierceness = 0.0
+                        npc.speed = 0.0
+                    self.map.eggs[y][x] = []
+                    self.map.burrows[y][x] = None
+                    self.map.plants[y][x] = []
+                    continue
+                if tname != "toxic_badlands":
                     continue
                 for npc in list(self.map.animals[y][x]):
                     if not npc.alive:

--- a/tests/test_lava.py
+++ b/tests/test_lava.py
@@ -1,0 +1,34 @@
+import random
+import dinosurvival.game as game_mod
+from dinosurvival.dinosaur import NPCAnimal
+from dinosurvival.map import EggCluster, Burrow
+from dinosurvival.plant import Plant
+from dinosurvival.settings import MORRISON
+
+
+def test_player_dies_on_lava_tile():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.grid[game.y][game.x] = MORRISON.terrains["lava"]
+    game.turn_messages = []
+    game._apply_terrain_effects()
+    assert game.player.health == 0.0
+    assert any("Game Over" in m for m in game.turn_messages)
+
+
+def test_lava_clears_cell_contents():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    x, y = 1, 1
+    game.map.grid[y][x] = MORRISON.terrains["volcano_erupting"]
+    npc = NPCAnimal(id=1, name="Stegosaurus", sex=None, weight=10.0)
+    game.map.animals[y][x] = [npc]
+    game.map.eggs[y][x] = [EggCluster(species="Stegosaurus", number=1, weight=1.0, turns_until_hatch=5)]
+    game.map.burrows[y][x] = Burrow(full=True)
+    game.map.plants[y][x] = [Plant(name="Ferns", weight=5.0)]
+    game._apply_terrain_effects()
+    assert not npc.alive
+    assert game.map.eggs[y][x] == []
+    assert game.map.burrows[y][x] is None
+    assert game.map.plants[y][x] == []
+


### PR DESCRIPTION
## Summary
- kill player instantly if standing on lava or erupting volcano
- kill NPCs and remove eggs, burrows, and plants from lava or erupting volcano tiles
- add regression tests for new lava behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fabd546f4832eb24d1c54d1baf468