### PR TITLE
Improve biome labels and earthquake message

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -36,6 +36,10 @@ def load_scaled_image(path: str, width: int, height: int, master=None, grayscale
         return ImageTk.PhotoImage(resized, master=master)
     return tk.PhotoImage(master=master, file=path)
 
+def format_biome_name(name: str) -> str:
+    """Return a human friendly biome name."""
+    return name.replace("_", " ").title()
+
 SETTINGS = {
     "morrison": MORRISON,
     "hell_creek": HELL_CREEK,
@@ -449,7 +453,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
 
     def update_biome() -> None:
         terrain = game.map.terrain_at(game.x, game.y)
-        label = terrain.name.capitalize()
+        label = format_biome_name(terrain.name)
         if game.map.has_nest(game.x, game.y):
             label += " (Nest)"
         label += f" ({game.x},{game.y})"
@@ -1112,7 +1116,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         ]
         for b in game.setting.terrains.keys():
             c = game.biome_turns.get(b, 0)
-            lines.append(f"- {b.capitalize()}: {c}")
+            lines.append(f"- {format_biome_name(b)}: {c}")
         lines.append("")
         lines.append("Hunts:")
         for a, (att, kill) in sorted(

--- a/dinosurvival/map.py
+++ b/dinosurvival/map.py
@@ -275,6 +275,9 @@ class Map:
         if self.terrain_at(x, y).name != "volcano":
             return messages
 
+        if player_pos is not None:
+            messages.append("You feel an earthquake.")
+
         steps_map = {"small": 0, "medium": 2, "large": 4}
         steps = steps_map.get(size, 0)
 


### PR DESCRIPTION
## Summary
- display biome names with spaces and title case
- report earthquake to player whenever a volcano erupts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd33a3ad8832ebd0a427fd26983bd