### PR TITLE
Preserve volcano tiles after eruptions

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -469,7 +469,7 @@ class Game:
         self.turn_messages.extend(
             self.map.update_volcanic_activity((self.x, self.y))
         )
-        if self.map.terrain_at(self.x, self.y).name == "lava":
+        if self.map.terrain_at(self.x, self.y).name in ("lava", "volcano_erupting"):
             append_event_log(f"Player killed by lava at ({self.x},{self.y})")
             return "\nYou are consumed by lava! Game Over."
         self.turn_messages.extend(self._update_eggs())

--- a/dinosurvival/map.py
+++ b/dinosurvival/map.py
@@ -292,8 +292,13 @@ class Map:
             self.eggs[ay][ax] = []
             self.burrows[ay][ax] = None
 
-            self.grid[ay][ax] = self.terrains["lava"]
-            spread_steps = steps if (ax == x and ay == y) else max(steps - 1, 0)
+            if ax == x and ay == y:
+                self.grid[ay][ax] = self.terrains["volcano_erupting"]
+                spread_steps = steps
+            else:
+                self.grid[ay][ax] = self.terrains["lava"]
+                spread_steps = max(steps - 1, 0)
+
             self.lava_info[ay][ax] = {"steps": spread_steps, "cooldown": 1}
             if player_pos is not None and (ax, ay) == player_pos:
                 messages.append("A volcano erupts beneath you!")
@@ -320,7 +325,11 @@ class Map:
                         (x, y - 1),
                     ):
                         if 0 <= nx < self.width and 0 <= ny < self.height:
-                            if self.lava_info[ny][nx] is None:
+                            if (
+                                self.lava_info[ny][nx] is None
+                                and self.grid[ny][nx].name
+                                not in ("volcano", "volcano_erupting")
+                            ):
                                 new_lava.append((nx, ny, info["steps"] - 1))
                     info["steps"] -= 1
                 else:
@@ -338,7 +347,10 @@ class Map:
                 messages.append("Lava flows over you!")
 
         for x, y in to_solidify:
-            self.grid[y][x] = self.terrains["solidified_lava_field"]
+            if self.grid[y][x].name == "volcano_erupting":
+                self.grid[y][x] = self.terrains["volcano"]
+            else:
+                self.grid[y][x] = self.terrains["solidified_lava_field"]
             self.lava_info[y][x] = None
             self.erupting[y][x] = False
 

--- a/tests/test_volcano_eruption.py
+++ b/tests/test_volcano_eruption.py
@@ -23,7 +23,7 @@ def test_player_dies_on_volcano_eruption():
     random.seed(SEED_ERUPT)
     result = game._start_turn()
     assert "Game Over" in result
-    assert game.map.grid[3][3].name == "lava"
+    assert game.map.grid[3][3].name == "volcano_erupting"
     game._apply_terrain_effects()
     assert game.player.health == 0.0
 
@@ -34,6 +34,6 @@ def test_player_dies_adjacent_volcano_eruption():
     result = game._start_turn()
     assert "Game Over" in result
     assert game.map.grid[2][3].name == "lava"
-    assert game.map.grid[3][3].name == "lava"
+    assert game.map.grid[3][3].name == "volcano_erupting"
     game._apply_terrain_effects()
     assert game.player.health == 0.0

--- a/tests/test_volcano_persistence.py
+++ b/tests/test_volcano_persistence.py
@@ -1,0 +1,22 @@
+import random
+import dinosurvival.game as game_mod
+from dinosurvival.settings import MORRISON
+
+
+def test_volcano_tile_remains_after_eruption():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    for j in range(game.map.height):
+        for i in range(game.map.width):
+            game.map.grid[j][i] = MORRISON.terrains["plains"]
+            game.map.lava_info[j][i] = None
+            game.map.erupting[j][i] = False
+    game.map.grid[3][3] = MORRISON.terrains["volcano"]
+
+    game.map.start_volcano_eruption(3, 3, "medium")
+    assert game.map.grid[3][3].name == "volcano_erupting"
+
+    for _ in range(3):
+        game.map.update_lava()
+
+    assert game.map.grid[3][3].name == "volcano"


### PR DESCRIPTION
## Summary
- keep volcano tiles intact when eruptions occur
- prevent lava flow from overwriting volcanoes
- end eruptions by reverting `volcano_erupting` back to `volcano`
- update start-turn death check for volcano eruptions
- adjust volcano eruption tests and add persistence test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860016a263c832e85104c4f076cc8ba