### PR TITLE
Fix Hell Creek info windows

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -94,6 +94,10 @@ def choose_dinosaur_gui(root: tk.Tk, setting, on_select, on_back=None) -> None:
     closing the application.
     """
 
+    # Ensure the correct stats are loaded for the selected formation so that
+    # the information and statistics windows display properly.
+    game_module.set_stats_for_formation(setting.formation)
+
     frame = tk.Frame(root)
     frame.pack(expand=True)
 


### PR DESCRIPTION
## Summary
- load the proper formation stats before showing the dinosaur menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686012252d80832e8fe9065cf8de2432