### PR TITLE
Fix hunting damage for critters

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -369,7 +369,9 @@ class Game:
             npc = entry.npc
             if not npc.alive:
                 continue
-            stats = DINO_STATS.get(npc.name, {})
+            stats = DINO_STATS.get(npc.name)
+            if not stats:
+                stats = CRITTER_STATS.get(npc.name, {})
             if not stats.get("aggressive"):
                 continue
             target_f = self.npc_effective_fierceness(npc, stats, self.x, self.y)
@@ -1208,7 +1210,9 @@ class Game:
                         for other in animals:
                             if other is npc or not other.alive:
                                 continue
-                            o_stats = DINO_STATS.get(other.name, {})
+                            o_stats = DINO_STATS.get(other.name)
+                            if not o_stats:
+                                o_stats = CRITTER_STATS.get(other.name, {})
                             o_f = self.npc_effective_fierceness(other, o_stats, x, y)
                             if o_f >= npc_f:
                                 continue
@@ -1286,7 +1290,9 @@ class Game:
             hunt = self.hunt_stats.setdefault(target.name, [0, 0])
             hunt[0] += 1
 
-        stats = DINO_STATS.get(target.name, {})
+        stats = DINO_STATS.get(target.name)
+        if not stats:
+            stats = CRITTER_STATS.get(target.name, {})
 
         player_speed = self.player_effective_speed()
 

--- a/tests/test_hunts.py
+++ b/tests/test_hunts.py
@@ -1,7 +1,7 @@
 import random
 import dinosurvival.game as game_mod
 from dinosurvival.dinosaur import NPCAnimal
-from dinosurvival.settings import MORRISON
+from dinosurvival.settings import MORRISON, HELL_CREEK
 
 
 def test_live_hunt_counts_kill():
@@ -23,3 +23,25 @@ def test_carcass_eat_not_counted_as_hunt():
     game.map.animals[game.y][game.x] = [carcass]
     game.hunt_npc(carcass.id)
     assert "Stegosaurus" not in game.hunt_stats
+
+
+def test_player_takes_damage_when_hunting_critter():
+    random.seed(0)
+    game = game_mod.Game(HELL_CREEK, "Tyrannosaurus", width=6, height=6)
+    game.player.health_regen = 0
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    critter = NPCAnimal(id=1, name="Didelphodon", sex=None, weight=5.0)
+    game.map.animals[game.y][game.x] = [critter]
+    game.hunt_npc(critter.id)
+    assert game.player.health < 100
+
+
+def test_npc_takes_damage_when_hunting_critter():
+    random.seed(0)
+    game = game_mod.Game(HELL_CREEK, "Tyrannosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    predator = NPCAnimal(id=1, name="Acheroraptor", sex=None, weight=10.0, energy=50.0)
+    prey = NPCAnimal(id=2, name="Didelphodon", sex=None, weight=5.0)
+    game.map.animals[0][0] = [predator, prey]
+    game._update_npcs()
+    assert predator.health < 100


### PR DESCRIPTION
## Summary
- ensure critters use their stats when hunted
- consider critter stats when NPCs hunt or attack
- test that hunting critters damages player and NPCs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860278ebd38832e934a70d98cbcb998