### PR TITLE
Add forest fire alert and weather effect display

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -512,7 +512,7 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         img = weather_images.get(w.name)
         if img is None and w.icon:
             abs_path = os.path.join(os.path.dirname(__file__), w.icon)
-            weather_images[w.name] = load_scaled_image(abs_path, 256, 256)
+            weather_images[w.name] = load_scaled_image(abs_path, 128, 128)
             img = weather_images.get(w.name)
         if img:
             weather_img_label.configure(image=img)
@@ -520,6 +520,14 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         else:
             weather_img_label.configure(image="")
             weather_img_label.image = None
+        effects: list[str] = []
+        if abs(w.player_hydration_mult - 1.0) > 0.01:
+            effects.append(f"Hydration x{w.player_hydration_mult:.2g}")
+        if abs(w.player_energy_mult - 1.0) > 0.01:
+            effects.append(f"Energy x{w.player_energy_mult:.2g}")
+        if w.flood_chance > 0:
+            effects.append(f"Flood {int(w.flood_chance * 100)}%")
+        weather_effect_var.set("\n".join(effects) if effects else "")
 
     def update_drink_button() -> None:
         terrain = game.map.terrain_at(game.x, game.y)
@@ -651,6 +659,8 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
     weather_img_label.pack(pady=5)
     weather_var = tk.StringVar()
     tk.Label(weather_frame, textvariable=weather_var, font=("Helvetica", 12)).pack()
+    weather_effect_var = tk.StringVar()
+    tk.Label(weather_frame, textvariable=weather_effect_var, font=("Helvetica", 10)).pack()
     weather_images: dict[str, tk.PhotoImage] = {}
 
     # Population tracker on the right below weather

--- a/dinosurvival/map.py
+++ b/dinosurvival/map.py
@@ -577,12 +577,15 @@ class Map:
         """Public helper to ignite a fire at ``(x, y)``."""
         messages: List[str] = []
         self._start_fire(x, y, player_pos, messages)
+        if self.grid[y][x].name in ("forest_fire", "highland_forest_fire"):
+            messages.append("There is a smell of burning in the air.")
         return messages
 
     def update_forest_fire(
         self, weather: "Weather", player_pos: Optional[Tuple[int, int]] = None
     ) -> List[str]:
         messages: List[str] = []
+        started_fire = False
 
         start_chance = 0.0
         if weather.name == "Sunny":
@@ -599,6 +602,7 @@ class Map:
                 if candidates:
                     cx, cy = self._fire_rng.choice(candidates)
                     self._start_fire(cx, cy, player_pos, messages)
+                    started_fire = True
 
         if weather.name == "Heatwave":
             spread_chance = 0.30
@@ -630,6 +634,7 @@ class Map:
 
         for nx, ny in to_spread:
             self._start_fire(nx, ny, player_pos, messages)
+            started_fire = True
 
         for x, y in to_burnt:
             name = self.grid[y][x].name
@@ -651,6 +656,9 @@ class Map:
                         elif name == "highland_forest_burnt":
                             self.grid[y][x] = self.terrains["highland_forest"]
 
+        if started_fire:
+            messages.append("There is a smell of burning in the air.")
+        
         return messages
 
     def _generate_noise(self, width: int, height: int, scale: int = 3) -> List[List[float]]:


### PR DESCRIPTION
## Summary
- show warning text when any forest fire ignites
- shrink weather icons in the GUI
- list current weather effects below the icon

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862da7bbe54832eaba4d23caa969902