### PR TITLE
Add armor mechanics to animals

### DIFF
--- a/dinosurvival/critter_stats_hell_creek.yaml
+++ b/dinosurvival/critter_stats_hell_creek.yaml
@@ -17,7 +17,9 @@
       "woodlands"
     ],
     "attack": 0.0,
-    "hp": 0.0
+    "hp": 0.0,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Didelphodon": {
     "adult_speed": 60,
@@ -36,6 +38,8 @@
       "forest"
     ],
     "attack": 0.36,
-    "hp": 0.72
+    "hp": 0.72,
+    "armor": 0,
+    "armor_penetration": 0
   }
 }

--- a/dinosurvival/critter_stats_morrison.yaml
+++ b/dinosurvival/critter_stats_morrison.yaml
@@ -16,7 +16,9 @@
       "forest"
     ],
     "attack": 0.0,
-    "hp": 0.0
+    "hp": 0.0,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Ceratodus": {
     "adult_speed": 55,
@@ -35,7 +37,9 @@
       "lake"
     ],
     "attack": 0.89,
-    "hp": 1.78
+    "hp": 1.78,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Dragonfly": {
     "adult_speed": 75,
@@ -54,7 +58,9 @@
       "forest"
     ],
     "attack": 0.0,
-    "hp": 0.0
+    "hp": 0.0,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Frog": {
     "adult_speed": 45,
@@ -73,7 +79,9 @@
       "swamp"
     ],
     "attack": 0.0,
-    "hp": 0.0
+    "hp": 0.0,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Glyptops": {
     "adult_speed": 45,
@@ -92,7 +100,9 @@
       "swamp"
     ],
     "attack": 0.54,
-    "hp": 1.08
+    "hp": 1.08,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Lizard": {
     "adult_speed": 55,
@@ -111,7 +121,9 @@
       "swamp"
     ],
     "attack": 0.89,
-    "hp": 1.78
+    "hp": 1.78,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Morrolepis": {
     "adult_speed": 65,
@@ -130,7 +142,9 @@
       "lake"
     ],
     "attack": 0.0,
-    "hp": 0.0
+    "hp": 0.0,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Scorpion": {
     "adult_speed": 65,
@@ -149,6 +163,8 @@
       "desert"
     ],
     "attack": 0.98,
-    "hp": 1.96
+    "hp": 1.96,
+    "armor": 0,
+    "armor_penetration": 0
   }
 }

--- a/dinosurvival/dino_stats_hell_creek.yaml
+++ b/dinosurvival/dino_stats_hell_creek.yaml
@@ -29,7 +29,9 @@
       "plains"
     ],
     "attack": 8.04,
-    "hp": 16.08
+    "hp": 16.08,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Ankylosaurus": {
     "adult_energy_drain": 1.5,
@@ -57,7 +59,9 @@
       "desert"
     ],
     "attack": 1285.71,
-    "hp": 2571.42
+    "hp": 2571.42,
+    "armor": 40,
+    "armor_penetration": 0
   },
   "Edmontosaurus": {
     "adult_energy_drain": 2.0,
@@ -86,7 +90,9 @@
       "plains"
     ],
     "attack": 535.71,
-    "hp": 1071.42
+    "hp": 1071.42,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Leptoceratops": {
     "adult_energy_drain": 3.5,
@@ -114,7 +120,9 @@
       "swamp"
     ],
     "attack": 8.04,
-    "hp": 16.08
+    "hp": 16.08,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Pachycephalosaurus": {
     "adult_energy_drain": 5.0,
@@ -143,7 +151,9 @@
       "forest"
     ],
     "attack": 44.64,
-    "hp": 89.28
+    "hp": 89.28,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Pectinodon": {
     "adult_energy_drain": 5.0,
@@ -175,7 +185,9 @@
       "plains"
     ],
     "attack": 3.21,
-    "hp": 6.42
+    "hp": 6.42,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Thescelosaurus": {
     "adult_energy_drain": 4.0,
@@ -203,7 +215,9 @@
       "plains"
     ],
     "attack": 26.79,
-    "hp": 53.58
+    "hp": 53.58,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Triceratops": {
     "adult_energy_drain": 2.0,
@@ -231,7 +245,9 @@
       "plains"
     ],
     "attack": 1071.43,
-    "hp": 2142.86
+    "hp": 2142.86,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Tyrannosaurus": {
     "abilities": [
@@ -264,6 +280,8 @@
       "plains"
     ],
     "attack": 1428.57,
-    "hp": 2857.14
+    "hp": 2857.14,
+    "armor": 0,
+    "armor_penetration": 20
   }
 }

--- a/dinosurvival/dino_stats_morrison.yaml
+++ b/dinosurvival/dino_stats_morrison.yaml
@@ -26,7 +26,9 @@
       "desert"
     ],
     "attack": 500.0,
-    "hp": 1000.0
+    "hp": 1000.0,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Allosaurus": {
     "adult_energy_drain": 5.0,
@@ -54,7 +56,9 @@
       "woodlands"
     ],
     "attack": 500.0,
-    "hp": 1000.0
+    "hp": 1000.0,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Amphicotylus": {
     "adult_energy_drain": 1.5,
@@ -81,7 +85,9 @@
       "lake"
     ],
     "attack": 50.0,
-    "hp": 100.0
+    "hp": 100.0,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Brachiosaurus": {
     "adult_energy_drain": 1.2,
@@ -109,7 +115,9 @@
       "woodlands"
     ],
     "attack": 2142.86,
-    "hp": 4285.72
+    "hp": 4285.72,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Camarasaurus": {
     "adult_energy_drain": 1.6,
@@ -138,7 +146,9 @@
       "woodlands"
     ],
     "attack": 964.29,
-    "hp": 1928.58
+    "hp": 1928.58,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Camptosaurus": {
     "adult_energy_drain": 3.6,
@@ -165,7 +175,9 @@
       "woodlands"
     ],
     "attack": 62.5,
-    "hp": 125.0
+    "hp": 125.0,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Ceratosaurus": {
     "adult_energy_drain": 4,
@@ -193,7 +205,9 @@
       "swamp"
     ],
     "attack": 178.57,
-    "hp": 357.14
+    "hp": 357.14,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Diplodocus": {
     "adult_energy_drain": 1.2,
@@ -221,7 +235,9 @@
       "plains"
     ],
     "attack": 1428.57,
-    "hp": 2857.14
+    "hp": 2857.14,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Dryosaurus": {
     "adult_energy_drain": 5.0,
@@ -250,7 +266,9 @@
       "woodlands"
     ],
     "attack": 8.93,
-    "hp": 17.86
+    "hp": 17.86,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Fruitadens": {
     "adult_energy_drain": 8.0,
@@ -278,7 +296,9 @@
       "swamp"
     ],
     "attack": 0.45,
-    "hp": 0.9
+    "hp": 0.9,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Gargoyleosaurus": {
     "adult_energy_drain": 5.0,
@@ -305,7 +325,9 @@
       "forest"
     ],
     "attack": 178.57,
-    "hp": 357.14
+    "hp": 357.14,
+    "armor": 40,
+    "armor_penetration": 0
   },
   "Mymoorapelta": {
     "adult_energy_drain": 5.0,
@@ -333,7 +355,9 @@
       "woodlands"
     ],
     "attack": 98.21,
-    "hp": 196.42
+    "hp": 196.42,
+    "armor": 40,
+    "armor_penetration": 0
   },
   "Nanosaurus": {
     "adult_energy_drain": 7.0,
@@ -360,7 +384,9 @@
       "forest"
     ],
     "attack": 1.07,
-    "hp": 2.14
+    "hp": 2.14,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Ornitholestes": {
     "adult_energy_drain": 4.0,
@@ -387,7 +413,9 @@
       "forest"
     ],
     "attack": 4.46,
-    "hp": 8.92
+    "hp": 8.92,
+    "armor": 0,
+    "armor_penetration": 0
   },
   "Stegosaurus": {
     "adult_energy_drain": 3.0,
@@ -417,7 +445,9 @@
       "plains"
     ],
     "attack": 464.29,
-    "hp": 928.58
+    "hp": 928.58,
+    "armor": 20,
+    "armor_penetration": 0
   },
   "Torvosaurus": {
     "adult_energy_drain": 4.0,
@@ -445,6 +475,8 @@
       "forest"
     ],
     "attack": 464.29,
-    "hp": 928.58
+    "hp": 928.58,
+    "armor": 0,
+    "armor_penetration": 10
   }
 }

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -25,3 +25,32 @@ def test_npc_target_selection():
     # predator should not attack equal strength target
     assert predator.health == 100
 
+
+def test_damage_after_armor_function():
+    dmg = game_mod.damage_after_armor(
+        100,
+        {"armor_penetration": 20},
+        {"armor": 40},
+    )
+    assert dmg == 80
+
+
+def test_armor_reduces_damage_in_hunt():
+    random.seed(0)
+    game1 = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game1.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    npc1 = NPCAnimal(id=1, name="Dryosaurus", sex=None, weight=80.0)
+    game1.map.animals[game1.y][game1.x] = [npc1]
+    game1.hunt_npc(npc1.id)
+    damage_unarm = 100 - npc1.health
+
+    random.seed(0)
+    game2 = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game2.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    npc2 = NPCAnimal(id=1, name="Stegosaurus", sex=None, weight=80.0)
+    game2.map.animals[game2.y][game2.x] = [npc2]
+    game2.hunt_npc(npc2.id)
+    damage_arm = 100 - npc2.health
+
+    assert damage_arm < damage_unarm
+


### PR DESCRIPTION
## Summary
- introduce armor and armor penetration stats
- compute damage after applying armor and penetration
- adjust NPC combat logic to use armor
- set armor and penetration values in dino and critter stats
- add tests for armor and penetration mechanics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686441468098832ea675c43caca35db0