### PR TITLE
Fix duplicate damage message

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -1505,6 +1505,7 @@ class Game:
 
         player_attack = self.player_effective_attack()
         died_player = False
+        target_died = False
         if target.alive:
             before = self.player.hp
             dmg_from_target = damage_after_armor(
@@ -1532,15 +1533,6 @@ class Game:
                 self.turn_messages.append(
                     f"You deal {dealt:.0f} damage to the {self._npc_label(target)}."
                 )
-        if died_player:
-                self.turn_messages.extend(self._update_npcs())
-                self._move_npcs()
-                self.turn_messages.extend(self._spoil_carcasses())
-                self._generate_encounters()
-                self._reveal_adjacent_mountains()
-                return self._finish_turn(
-                    f"You fought the {self._npc_label(target)} but received fatal injuries. Game Over."
-                )
         else:
             player_damage = 0.0
             before_t = target.hp
@@ -1554,6 +1546,16 @@ class Game:
             if dealt > 0:
                 self.turn_messages.append(
                     f"You deal {dealt:.0f} damage to the {self._npc_label(target)}."
+                )
+
+        if died_player:
+                self.turn_messages.extend(self._update_npcs())
+                self._move_npcs()
+                self.turn_messages.extend(self._spoil_carcasses())
+                self._generate_encounters()
+                self._reveal_adjacent_mountains()
+                return self._finish_turn(
+                    f"You fought the {self._npc_label(target)} but received fatal injuries. Game Over."
                 )
 
         if not target_died:

--- a/tests/test_damage_message.py
+++ b/tests/test_damage_message.py
@@ -1,0 +1,18 @@
+import random
+import dinosurvival.game as game_mod
+from dinosurvival.dinosaur import NPCAnimal
+from dinosurvival.settings import HELL_CREEK
+
+
+def test_hunt_only_one_damage_message():
+    random.seed(0)
+    game = game_mod.Game(HELL_CREEK, "Tyrannosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    stats = game_mod.CRITTER_STATS["Didelphodon"]
+    weight = stats["adult_weight"]
+    hp = game._scale_by_weight(weight, stats, "hp")
+    npc = NPCAnimal(id=1, name="Didelphodon", sex=None, weight=weight, max_hp=hp, hp=hp)
+    game.map.animals[game.y][game.x] = [npc]
+    game.hunt_npc(npc.id)
+    count = sum(1 for m in game.turn_messages if m.startswith("You deal"))
+    assert count == 1


### PR DESCRIPTION
## Summary
- avoid double-damage message when hunting NPCs
- add regression test for damage log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645ad2ba04832eabdcfc528bb2e479