### PR TITLE
Fix carcass spoilage message accuracy

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -1064,8 +1064,10 @@ class Game:
                 for npc in list(animals):
                     if not npc.alive:
                         before = npc.weight
-                        npc.weight -= npc.weight * 0.10 + 2
-                        lost = max(0.0, before - npc.weight)
+                        spoiled = npc.weight * 0.10 + 2
+                        after = max(0.0, npc.weight - spoiled)
+                        npc.weight = after
+                        lost = before - after
                         if lost > 0 and x == self.x and y == self.y:
                             messages.append(
                                 f"The {self._npc_label(npc)} carcass lost {lost:.1f}kg to spoilage."

--- a/tests/test_carcass_spoilage.py
+++ b/tests/test_carcass_spoilage.py
@@ -40,3 +40,17 @@ def test_spoilage_occurs_after_turn():
     assert carcass.weight == 1.0
     game.turn("stay")
     assert carcass not in game.map.animals[game.y][game.x]
+
+
+def test_spoilage_message_clamped_to_remaining_weight():
+    random.seed(0)
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    carcass = NPCAnimal(id=4, name="Stegosaurus", sex=None, alive=False, weight=1.0)
+    game.map.animals[game.y][game.x] = [carcass]
+
+    messages = game._spoil_carcasses()
+
+    expected = f"The {game._npc_label(carcass)} carcass lost 1.0kg to spoilage."
+    assert messages == [expected]
+    assert carcass not in game.map.animals[game.y][game.x]


### PR DESCRIPTION
## Summary
- adjust spoilage to clamp weight removal at zero
- add regression test for spoilage message when carcass weight is low

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864676bf408832e8d87a075093e7589