### PR TITLE
Scale attack by HP percentage

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -505,7 +505,10 @@ class Game:
         atk = self.player.attack
         if self.player_pack_hunter_active():
             atk *= 3
-        return atk
+        hp_pct = 1.0
+        if self.player.max_hp > 0:
+            hp_pct = max(0.0, min(self.player.hp / self.player.max_hp, 1.0))
+        return atk * hp_pct
 
     def player_effective_speed(self) -> float:
         speed = self.player.speed
@@ -542,7 +545,10 @@ class Game:
         atk = self._scale_by_weight(npc.weight, stats, "attack")
         if "pack_hunter" in npc.abilities and self._npc_has_packmate(npc, x, y):
             atk *= 3
-        return atk
+        hp_pct = 1.0
+        if npc.max_hp > 0:
+            hp_pct = max(0.0, min(npc.hp / npc.max_hp, 1.0))
+        return atk * hp_pct
 
     def _start_turn(self) -> str:
         self.turn_messages = []

--- a/tests/test_attack_hp_scaling.py
+++ b/tests/test_attack_hp_scaling.py
@@ -1,0 +1,25 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import dinosurvival.game as game_mod
+from dinosurvival.dinosaur import NPCAnimal
+from dinosurvival.settings import MORRISON
+
+
+def test_player_attack_scales_with_hp():
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    game.player.weight = game.player.adult_weight
+    pct = game.player.weight / game.player.adult_weight
+    game.player.attack = game.player.adult_attack * pct
+    game.player.hp = game.player.max_hp / 2
+    assert game.player_effective_attack() == game.player.adult_attack * 0.5
+
+
+def test_npc_attack_scales_with_hp():
+    game = game_mod.Game(MORRISON, "Allosaurus", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    npc = NPCAnimal(id=1, name="Stegosaurus", sex=None, weight=1.0, hp=50.0, max_hp=100.0)
+    stats = game_mod.DINO_STATS["Stegosaurus"]
+    game.map.animals[0][0] = [npc]
+    expected = game._scale_by_weight(npc.weight, stats, "attack") * 0.5
+    assert game.npc_effective_attack(npc, stats, 0, 0) == expected


### PR DESCRIPTION
## Summary
- adjust `player_effective_attack` and `npc_effective_attack` to multiply attack by remaining hp percentage
- add tests covering attack scaling with hp

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865833b91d4832eb31fe9c880b935f6