### PR TITLE
Show NPC and species abilities

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -525,10 +525,16 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
             lbl_e.image = icons["energy"]
         lbl_e.configure(text=f"{npc.energy:.0f}%")
         lbl_e.pack(anchor="w")
-        abil = "None"
-        if "ambush" in npc.abilities:
-            bonus = min(npc.ambush_streak, 3) * 5
-            abil = f"Ambush ({npc.ambush_streak} stacks) +{bonus}% speed"
+        abilities = []
+        for ability in npc.abilities:
+            if ability == "ambush":
+                bonus = min(npc.ambush_streak, 3) * 5
+                abilities.append(
+                    f"Ambush ({npc.ambush_streak} stacks) +{bonus}% speed"
+                )
+            else:
+                abilities.append(ability)
+        abil = ", ".join(abilities) if abilities else "None"
         tk.Label(
             win, text=f"Abilities: {abil}", font=("Helvetica", 12), anchor="w"
         ).pack(anchor="w")


### PR DESCRIPTION
## Summary
- show NPC abilities in the encounter stats window
- include the ability list when viewing dinosaur species information

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d930c95c832ea2ee97db5fccc250