### PR TITLE
Add abilities to species info

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -453,6 +453,14 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
         tk.Label(win, text=f"Diet: {diet}", font=("Helvetica", 12), anchor="w").pack(
             anchor="w"
         )
+        abilities = ", ".join(info.get("abilities", []))
+        if abilities:
+            tk.Label(
+                win,
+                text=f"Abilities: {abilities}",
+                font=("Helvetica", 12),
+                anchor="w",
+            ).pack(anchor="w")
         interval = info.get("egg_laying_interval")
         if interval is not None:
             tk.Label(


### PR DESCRIPTION
## Summary
- display abilities on the species info page opened from the Global Population panel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866ded77478832e9477c2e71c5420c9