### PR TITLE
Implement armor abilities and bone break improvements

### DIFF
--- a/dinosurvival/critter_stats_hell_creek.yaml
+++ b/dinosurvival/critter_stats_hell_creek.yaml
@@ -4,42 +4,38 @@
     "adult_weight": 1.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 0.0,
     "avg_spawned_per_turn": 1.0,
     "can_be_juvenile": false,
     "can_walk": true,
     "class": "arthropod",
     "health_regen": 2.5,
+    "hp": 1.0,
     "image": "assets/dinosaurs/centipede.png",
     "maximum_individuals": 20,
     "name": "Centipede",
     "preferred_biomes": [
       "forest",
       "woodlands"
-    ],
-    "attack": 0.0,
-    "hp": 1.0,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Didelphodon": {
     "adult_speed": 60,
     "adult_weight": 5.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 0.36,
     "avg_spawned_per_turn": 0.0,
     "can_be_juvenile": false,
     "can_walk": true,
     "class": "mammal",
     "health_regen": 2.5,
+    "hp": 0.72,
     "image": "assets/dinosaurs/didelphodon.png",
     "maximum_individuals": 0,
     "name": "Didelphodon",
     "preferred_biomes": [
       "forest"
-    ],
-    "attack": 0.36,
-    "hp": 0.72,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   }
 }

--- a/dinosurvival/critter_stats_morrison.yaml
+++ b/dinosurvival/critter_stats_morrison.yaml
@@ -4,125 +4,113 @@
     "adult_weight": 1.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 0.0,
     "avg_spawned_per_turn": 1.0,
     "can_be_juvenile": false,
     "can_walk": true,
     "class": "arthropod",
     "health_regen": 2.5,
+    "hp": 1.0,
     "image": "assets/dinosaurs/centipede.png",
     "maximum_individuals": 20,
     "name": "Centipede",
     "preferred_biomes": [
       "forest"
-    ],
-    "attack": 0.0,
-    "hp": 1.0,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Ceratodus": {
     "adult_speed": 55,
     "adult_weight": 12.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 0.89,
     "avg_spawned_per_turn": 1.0,
     "can_be_juvenile": false,
     "can_walk": false,
     "class": "fish",
     "health_regen": 2.5,
+    "hp": 1.78,
     "image": "assets/dinosaurs/ceratodus.png",
     "maximum_individuals": 20,
     "name": "Ceratodus",
     "preferred_biomes": [
       "lake"
-    ],
-    "attack": 0.89,
-    "hp": 1.78,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Frog": {
     "adult_speed": 45,
     "adult_weight": 2.5,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 0.0,
     "avg_spawned_per_turn": 1.0,
     "can_be_juvenile": false,
     "can_walk": true,
     "class": "amphibian",
     "health_regen": 2.5,
+    "hp": 1.0,
     "image": "assets/dinosaurs/frog.png",
     "maximum_individuals": 20,
     "name": "Frog",
     "preferred_biomes": [
       "swamp"
-    ],
-    "attack": 0.0,
-    "hp": 1.0,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Glyptops": {
     "adult_speed": 45,
     "adult_weight": 5.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 0.54,
     "avg_spawned_per_turn": 1.0,
     "can_be_juvenile": false,
     "can_walk": true,
     "class": "reptile",
     "health_regen": 2.0,
+    "hp": 1.08,
     "image": "assets/dinosaurs/glyptops.png",
     "maximum_individuals": 20,
     "name": "Glyptops",
     "preferred_biomes": [
       "swamp"
-    ],
-    "attack": 0.54,
-    "hp": 1.08,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Lizard": {
     "adult_speed": 55,
     "adult_weight": 4.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 0.89,
     "avg_spawned_per_turn": 1.0,
     "can_be_juvenile": false,
     "can_walk": true,
     "class": "reptile",
     "health_regen": 2.5,
+    "hp": 1.78,
     "image": "assets/dinosaurs/lizard.png",
     "maximum_individuals": 20,
     "name": "Lizard",
     "preferred_biomes": [
       "swamp"
-    ],
-    "attack": 0.89,
-    "hp": 1.78,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Scorpion": {
     "adult_speed": 65,
     "adult_weight": 2.0,
     "aggressive": true,
     "aquatic_boost": 0.0,
+    "attack": 0.98,
     "avg_spawned_per_turn": 1.0,
     "can_be_juvenile": false,
     "can_walk": true,
     "class": "arthropod",
     "health_regen": 2.5,
+    "hp": 1.96,
     "image": "assets/dinosaurs/scorpion.png",
     "maximum_individuals": 20,
     "name": "Scorpion",
     "preferred_biomes": [
       "desert"
-    ],
-    "attack": 0.98,
-    "hp": 1.96,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   }
 }

--- a/dinosurvival/dino_stats_hell_creek.yaml
+++ b/dinosurvival/dino_stats_hell_creek.yaml
@@ -1,23 +1,25 @@
 {
   "Acheroraptor": {
+    "abilities": [
+      "bleed"
+    ],
     "adult_energy_drain": 5.0,
     "adult_speed": 100,
     "adult_weight": 30.0,
     "aggressive": true,
     "aquatic_boost": 0.0,
+    "attack": 8.04,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
     "diet": [
       "meat"
     ],
-    "abilities": [
-      "bleed"
-    ],
     "egg_laying_interval": 10,
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 16.08,
     "hydration_drain": 2.2,
     "image": "assets/dinosaurs/acheroraptor.png",
     "initial_spawn_multiplier": 5,
@@ -27,31 +29,30 @@
       "forest",
       "swamp",
       "plains"
-    ],
-    "attack": 8.04,
-    "hp": 16.08,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Ankylosaurus": {
+    "abilities": [
+      "bone_break",
+      "heavy_armor"
+    ],
     "adult_energy_drain": 1.5,
     "adult_speed": 15,
     "adult_weight": 6800.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 1285.71,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
     "diet": [
       "ferns"
     ],
-    "abilities": [
-      "bone_break"
-    ],
     "egg_laying_interval": 18,
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 2571.42,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/ankylosaurus.png",
     "initial_spawn_multiplier": 4,
@@ -60,11 +61,7 @@
     "preferred_biomes": [
       "forest",
       "desert"
-    ],
-    "attack": 1285.71,
-    "hp": 2571.42,
-    "armor": 40,
-    "armor_penetration": 0
+    ]
   },
   "Edmontosaurus": {
     "adult_energy_drain": 2.0,
@@ -72,6 +69,7 @@
     "adult_weight": 6000.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 535.71,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -83,6 +81,7 @@
     "forms_packs": false,
     "growth_rate": 0.4,
     "health_regen": 2.5,
+    "hp": 1071.42,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/edmontosaurus.png",
     "initial_spawn_multiplier": 6,
@@ -91,11 +90,7 @@
     "preferred_biomes": [
       "swamp",
       "plains"
-    ],
-    "attack": 535.71,
-    "hp": 1071.42,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Leptoceratops": {
     "adult_energy_drain": 3.5,
@@ -103,6 +98,7 @@
     "adult_weight": 80.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 8.04,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -113,6 +109,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 16.08,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/leptoceratops.png",
     "initial_spawn_multiplier": 15,
@@ -121,11 +118,7 @@
     "preferred_biomes": [
       "forest",
       "swamp"
-    ],
-    "attack": 8.04,
-    "hp": 16.08,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Pachycephalosaurus": {
     "adult_energy_drain": 5.0,
@@ -133,6 +126,7 @@
     "adult_weight": 450.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 44.64,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -144,6 +138,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 89.28,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/pachycephalosaurus.png",
     "initial_spawn_multiplier": 12,
@@ -152,31 +147,29 @@
     "preferred_biomes": [
       "woodlands",
       "forest"
-    ],
-    "attack": 44.64,
-    "hp": 89.28,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Pectinodon": {
+    "abilities": [
+      "digger"
+    ],
     "adult_energy_drain": 5.0,
     "adult_speed": 160,
     "adult_weight": 25.0,
     "aggressive": true,
     "aquatic_boost": 0.0,
+    "attack": 3.21,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
     "diet": [
       "meat"
     ],
-    "abilities": [
-      "digger"
-    ],
     "egg_laying_interval": 12,
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 6.42,
     "hydration_drain": 2.2,
     "image": "assets/dinosaurs/pectinodon.png",
     "initial_spawn_multiplier": 5,
@@ -186,11 +179,7 @@
       "woodlands",
       "swamp",
       "plains"
-    ],
-    "attack": 3.21,
-    "hp": 6.42,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Thescelosaurus": {
     "adult_energy_drain": 4.0,
@@ -198,6 +187,7 @@
     "adult_weight": 300.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 26.79,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -208,6 +198,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 53.58,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/thescelosaurus.png",
     "initial_spawn_multiplier": 12,
@@ -216,11 +207,7 @@
     "preferred_biomes": [
       "woodlands",
       "plains"
-    ],
-    "attack": 26.79,
-    "hp": 53.58,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Triceratops": {
     "adult_energy_drain": 2.0,
@@ -228,6 +215,7 @@
     "adult_weight": 8000.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 1071.43,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -238,6 +226,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 2142.86,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/triceratops.png",
     "initial_spawn_multiplier": 5,
@@ -246,21 +235,19 @@
     "preferred_biomes": [
       "woodlands",
       "plains"
-    ],
-    "attack": 1071.43,
-    "hp": 2142.86,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Tyrannosaurus": {
     "abilities": [
-      "ambush"
+      "ambush",
+      "bone_break"
     ],
     "adult_energy_drain": 4.0,
     "adult_speed": 38,
     "adult_weight": 8000.0,
     "aggressive": true,
     "aquatic_boost": 0.0,
+    "attack": 1428.57,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -271,6 +258,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 2857.14,
     "hydration_drain": 2.2,
     "image": "assets/dinosaurs/tyrannosaurus.png",
     "initial_spawn_multiplier": 2,
@@ -281,10 +269,6 @@
       "forest",
       "swamp",
       "plains"
-    ],
-    "attack": 1428.57,
-    "hp": 2857.14,
-    "armor": 0,
-    "armor_penetration": 20
+    ]
   }
 }

--- a/dinosurvival/dino_stats_morrison.yaml
+++ b/dinosurvival/dino_stats_morrison.yaml
@@ -1,23 +1,25 @@
 {
   "Allosaurus": {
+    "abilities": [
+      "bleed"
+    ],
     "adult_energy_drain": 5.0,
     "adult_speed": 30,
     "adult_weight": 3000.0,
     "aggressive": true,
     "aquatic_boost": 0.0,
+    "attack": 500.0,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
     "diet": [
       "meat"
     ],
-    "abilities": [
-      "bleed"
-    ],
     "egg_laying_interval": 10,
     "forms_packs": true,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 1000.0,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/allosaurus.png",
     "initial_spawn_multiplier": 2,
@@ -26,11 +28,7 @@
     "preferred_biomes": [
       "plains",
       "woodlands"
-    ],
-    "attack": 500.0,
-    "hp": 1000.0,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Brachiosaurus": {
     "adult_energy_drain": 1.2,
@@ -38,6 +36,7 @@
     "adult_weight": 45000.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 2142.86,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -48,6 +47,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 4285.72,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/brachiosaurus.png",
     "initial_spawn_multiplier": 3,
@@ -56,11 +56,7 @@
     "preferred_biomes": [
       "plains",
       "woodlands"
-    ],
-    "attack": 2142.86,
-    "hp": 4285.72,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Camarasaurus": {
     "adult_energy_drain": 1.6,
@@ -68,6 +64,7 @@
     "adult_weight": 15000.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 964.29,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -79,6 +76,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 1928.58,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/camarasaurus.png",
     "initial_spawn_multiplier": 3,
@@ -87,11 +85,7 @@
     "preferred_biomes": [
       "desert",
       "woodlands"
-    ],
-    "attack": 964.29,
-    "hp": 1928.58,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Camptosaurus": {
     "adult_energy_drain": 3.6,
@@ -99,6 +93,7 @@
     "adult_weight": 700.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 62.5,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -109,6 +104,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 125.0,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/camptosaurus.png",
     "initial_spawn_multiplier": 6,
@@ -116,11 +112,7 @@
     "num_eggs": 2,
     "preferred_biomes": [
       "woodlands"
-    ],
-    "attack": 62.5,
-    "hp": 125.0,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Ceratosaurus": {
     "adult_energy_drain": 4,
@@ -128,6 +120,7 @@
     "adult_weight": 900.0,
     "aggressive": true,
     "aquatic_boost": 40.0,
+    "attack": 178.57,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -138,6 +131,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 357.14,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/ceratosaurus.png",
     "initial_spawn_multiplier": 3,
@@ -146,11 +140,7 @@
     "preferred_biomes": [
       "forest",
       "swamp"
-    ],
-    "attack": 178.57,
-    "hp": 357.14,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Diplodocus": {
     "adult_energy_drain": 1.2,
@@ -158,6 +148,7 @@
     "adult_weight": 25000.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 1428.57,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -169,6 +160,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 2857.14,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/diplodocus.png",
     "initial_spawn_multiplier": 3,
@@ -176,11 +168,7 @@
     "num_eggs": 2,
     "preferred_biomes": [
       "plains"
-    ],
-    "attack": 1428.57,
-    "hp": 2857.14,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Dryosaurus": {
     "adult_energy_drain": 5.0,
@@ -188,6 +176,7 @@
     "adult_weight": 80.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 8.93,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -199,6 +188,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 17.86,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/dryosaurus.png",
     "initial_spawn_multiplier": 10,
@@ -207,18 +197,18 @@
     "preferred_biomes": [
       "forest",
       "woodlands"
-    ],
-    "attack": 8.93,
-    "hp": 17.86,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Gargoyleosaurus": {
+    "abilities": [
+      "heavy_armor"
+    ],
     "adult_energy_drain": 5.0,
     "adult_speed": 20,
     "adult_weight": 750.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 178.57,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -229,6 +219,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 357.14,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/gargoyleosaurus.png",
     "initial_spawn_multiplier": 5,
@@ -236,11 +227,7 @@
     "num_eggs": 2,
     "preferred_biomes": [
       "forest"
-    ],
-    "attack": 178.57,
-    "hp": 357.14,
-    "armor": 40,
-    "armor_penetration": 0
+    ]
   },
   "Nanosaurus": {
     "adult_energy_drain": 7.0,
@@ -248,6 +235,7 @@
     "adult_weight": 10.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 1.07,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -258,6 +246,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 2.14,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/nanosaurus.png",
     "initial_spawn_multiplier": 10,
@@ -265,11 +254,7 @@
     "num_eggs": 2,
     "preferred_biomes": [
       "forest"
-    ],
-    "attack": 1.07,
-    "hp": 2.14,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Ornitholestes": {
     "adult_energy_drain": 4.0,
@@ -277,6 +262,7 @@
     "adult_weight": 20.0,
     "aggressive": true,
     "aquatic_boost": 0.0,
+    "attack": 4.46,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -287,6 +273,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 8.92,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/ornitholestes.png",
     "initial_spawn_multiplier": 7,
@@ -294,18 +281,19 @@
     "num_eggs": 2,
     "preferred_biomes": [
       "forest"
-    ],
-    "attack": 4.46,
-    "hp": 8.92,
-    "armor": 0,
-    "armor_penetration": 0
+    ]
   },
   "Stegosaurus": {
+    "abilities": [
+      "bleed",
+      "light_armor"
+    ],
     "adult_energy_drain": 3.0,
     "adult_speed": 20,
     "adult_weight": 4000.0,
     "aggressive": false,
     "aquatic_boost": 0.0,
+    "attack": 464.29,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -313,13 +301,11 @@
       "ferns",
       "cycads"
     ],
-    "abilities": [
-      "bleed"
-    ],
     "egg_laying_interval": 10,
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 928.58,
     "hydration_drain": 2.5,
     "image": "assets/dinosaurs/stegosaurus.png",
     "initial_spawn_multiplier": 5,
@@ -329,18 +315,18 @@
       "woodlands",
       "forest",
       "plains"
-    ],
-    "attack": 464.29,
-    "hp": 928.58,
-    "armor": 20,
-    "armor_penetration": 0
+    ]
   },
   "Torvosaurus": {
+    "abilities": [
+      "bone_break"
+    ],
     "adult_energy_drain": 4.0,
     "adult_speed": 35,
     "adult_weight": 2400.0,
     "aggressive": true,
     "aquatic_boost": 0.0,
+    "attack": 464.29,
     "can_be_juvenile": true,
     "can_walk": true,
     "class": "reptile",
@@ -351,6 +337,7 @@
     "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
+    "hp": 928.58,
     "hydration_drain": 2.2,
     "image": "assets/dinosaurs/torvosaurus.png",
     "initial_spawn_multiplier": 2,
@@ -359,10 +346,6 @@
     "preferred_biomes": [
       "woodlands",
       "forest"
-    ],
-    "attack": 464.29,
-    "hp": 928.58,
-    "armor": 0,
-    "armor_penetration": 10
+    ]
   }
 }

--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -49,10 +49,25 @@ MIN_HATCHING_WEIGHT = _config.getfloat("DEFAULT", "min_hatching_weight", fallbac
 
 # Armor mechanics
 def effective_armor(target_stats: dict, attacker_stats: dict) -> float:
-    """Return the effective armor percentage for ``target_stats``."""
-    base = target_stats.get("armor", 0.0)
-    penetration = attacker_stats.get("armor_penetration", 0.0)
-    return max(0.0, base - penetration)
+    """Return the effective armor percentage for ``target_stats``.
+
+    Armor values are derived from abilities. ``light_armor`` grants 20% damage
+    reduction while ``heavy_armor`` grants 40%. If the attacker has the
+    ``bone_break`` ability the target's armor is halved for this attack.
+    """
+
+    abilities = target_stats.get("abilities", [])
+    base = 0.0
+    if "heavy_armor" in abilities:
+        base = 40.0
+    elif "light_armor" in abilities:
+        base = 20.0
+
+    attacker_abilities = attacker_stats.get("abilities", [])
+    if "bone_break" in attacker_abilities:
+        base *= 0.5
+
+    return max(0.0, base)
 
 
 def damage_after_armor(
@@ -1471,7 +1486,11 @@ class Game:
                                     and "bleed" in target.abilities
                                     and npc.alive
                                 ):
-                                    npc.bleeding = 5
+                                    bleed_turns = 2 if (
+                                        "light_armor" in npc.abilities
+                                        or "heavy_armor" in npc.abilities
+                                    ) else 5
+                                    npc.bleeding = bleed_turns
                                 if (
                                     dmg > 0
                                     and "bone_break" in target.abilities
@@ -1493,7 +1512,11 @@ class Game:
                                     and "bleed" in npc.abilities
                                     and target.alive
                                 ):
-                                    target.bleeding = 5
+                                    bleed_turns = 2 if (
+                                        "light_armor" in target.abilities
+                                        or "heavy_armor" in target.abilities
+                                    ) else 5
+                                    target.bleeding = bleed_turns
                                 if (
                                     dmg2 > 0
                                     and "bone_break" in npc.abilities
@@ -1628,7 +1651,11 @@ class Game:
                 and "bleed" in target.abilities
                 and self.player.hp > 0
             ):
-                self.player.bleeding = 5
+                bleed_turns = 2 if (
+                    "light_armor" in self.player.abilities
+                    or "heavy_armor" in self.player.abilities
+                ) else 5
+                self.player.bleeding = bleed_turns
             if (
                 dmg_from_target > 0
                 and "bone_break" in target.abilities
@@ -1649,7 +1676,11 @@ class Game:
             )
             target_died = self._apply_damage(dmg_to_target, target, stats)
             if dmg_to_target > 0 and "bleed" in self.player.abilities and target.hp > 0:
-                target.bleeding = 5
+                bleed_turns = 2 if (
+                    "light_armor" in target.abilities
+                    or "heavy_armor" in target.abilities
+                ) else 5
+                target.bleeding = bleed_turns
             if (
                 dmg_to_target > 0
                 and "bone_break" in self.player.abilities
@@ -1672,7 +1703,11 @@ class Game:
             )
             target_died = self._apply_damage(dmg_to_target, target, stats)
             if dmg_to_target > 0 and "bleed" in self.player.abilities and target.hp > 0:
-                target.bleeding = 5
+                bleed_turns = 2 if (
+                    "light_armor" in target.abilities
+                    or "heavy_armor" in target.abilities
+                ) else 5
+                target.bleeding = bleed_turns
             if (
                 dmg_to_target > 0
                 and "bone_break" in self.player.abilities

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -27,8 +27,8 @@ def test_npc_target_selection():
 def test_damage_after_armor_function():
     dmg = game_mod.damage_after_armor(
         100,
-        {"armor_penetration": 20},
-        {"armor": 40},
+        {"abilities": ["bone_break"]},
+        {"abilities": ["heavy_armor"]},
     )
     assert dmg == 80
 


### PR DESCRIPTION
## Summary
- add `light_armor` and `heavy_armor` abilities in stat files
- replace numeric armor and penetration with ability checks
- halve armor when attacker has `bone_break`
- reduce bleed duration on armored targets
- update unit tests for new damage calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e3a1339c832ebde83febda9b1512