### PR TITLE
Avoid bleeding dead animals

### DIFF
--- a/dinosurvival/game.py
+++ b/dinosurvival/game.py
@@ -1779,7 +1779,12 @@ class Game:
                 stats,
             )
             target_died = self._apply_damage(dmg_to_target, target, stats)
-            if dmg_to_target > 0 and "bleed" in self.player.abilities and target.hp > 0:
+            if (
+                dmg_to_target > 0
+                and "bleed" in self.player.abilities
+                and target.hp > 0
+                and target.alive
+            ):
                 bleed_turns = 2 if (
                     "light_armor" in target.abilities
                     or "heavy_armor" in target.abilities
@@ -1806,7 +1811,12 @@ class Game:
                 stats,
             )
             target_died = self._apply_damage(dmg_to_target, target, stats)
-            if dmg_to_target > 0 and "bleed" in self.player.abilities and target.hp > 0:
+            if (
+                dmg_to_target > 0
+                and "bleed" in self.player.abilities
+                and target.hp > 0
+                and target.alive
+            ):
                 bleed_turns = 2 if (
                     "light_armor" in target.abilities
                     or "heavy_armor" in target.abilities

--- a/tests/test_bleed_carcass.py
+++ b/tests/test_bleed_carcass.py
@@ -1,0 +1,18 @@
+import random
+import dinosurvival.game as game_mod
+from dinosurvival.dinosaur import NPCAnimal
+from dinosurvival.settings import HELL_CREEK
+
+
+def test_player_does_not_bleed_carcass():
+    random.seed(0)
+    game = game_mod.Game(HELL_CREEK, "Acheroraptor", width=6, height=6)
+    game.map.animals = [[[] for _ in range(6)] for _ in range(6)]
+    carcass = NPCAnimal(id=1, name="Triceratops", sex=None, alive=False, weight=100.0, hp=100.0, max_hp=100.0)
+    game.map.animals[game.y][game.x] = [carcass]
+    game.player.weight = game.player.adult_weight
+    game.player.attack = game.player.adult_attack
+    game.player.hp = game.player.adult_hp
+    game.player.speed = 1000.0
+    game.hunt_npc(carcass.id)
+    assert carcass.bleeding == 0


### PR DESCRIPTION
## Summary
- prevent bleed effects from applying to dead creatures
- test that carcasses don't gain bleed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686817d89a04832e83b6740e435a40d1