### PR TITLE
Remove unused pack mechanic

### DIFF
--- a/dino_game.py
+++ b/dino_game.py
@@ -881,41 +881,6 @@ def run_game_gui(setting, dinosaur_name: str) -> None:
                 b.config(state="disabled")
             show_final_stats("Victory", "Congratulations! Your lineage lives on!")
 
-    def do_pack_up(juvenile: bool) -> None:
-        result = game.pack_up(juvenile)
-        append_output(result)
-        update_biome()
-        update_stats()
-        update_drink_button()
-        update_lay_button()
-        update_encounters()
-        update_plants()
-        if "Game Over" in result:
-            for b in move_buttons.values():
-                b.config(state="disabled")
-            show_final_stats("Game Over", "You have perished!")
-        if game.won:
-            for b in move_buttons.values():
-                b.config(state="disabled")
-            show_final_stats("Victory", "Congratulations! Your lineage lives on!")
-
-    def do_leave_pack() -> None:
-        result = game.leave_pack()
-        append_output(result)
-        update_biome()
-        update_stats()
-        update_drink_button()
-        update_lay_button()
-        update_encounters()
-        update_plants()
-        if "Game Over" in result:
-            for b in move_buttons.values():
-                b.config(state="disabled")
-            show_final_stats("Game Over", "You have perished!")
-        if game.won:
-            for b in move_buttons.values():
-                b.config(state="disabled")
-            show_final_stats("Victory", "Congratulations! Your lineage lives on!")
 
     def do_collect_eggs() -> None:
         result = game.collect_eggs()

--- a/dinosurvival/dino_stats_hell_creek.yaml
+++ b/dinosurvival/dino_stats_hell_creek.yaml
@@ -16,7 +16,6 @@
       "meat"
     ],
     "egg_laying_interval": 10,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 30.0,
@@ -49,7 +48,6 @@
       "ferns"
     ],
     "egg_laying_interval": 18,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 6500.0,
@@ -78,7 +76,6 @@
       "cycads"
     ],
     "egg_laying_interval": 16,
-    "forms_packs": false,
     "growth_rate": 0.4,
     "health_regen": 2.5,
     "hp": 3000.0,
@@ -107,7 +104,6 @@
       "fruits"
     ],
     "egg_laying_interval": 9,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 40.0,
@@ -136,7 +132,6 @@
       "ferns"
     ],
     "egg_laying_interval": 14,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 240.0,
@@ -167,7 +162,6 @@
       "meat"
     ],
     "egg_laying_interval": 12,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 25.0,
@@ -196,7 +190,6 @@
       "ferns"
     ],
     "egg_laying_interval": 6,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 150.0,
@@ -228,7 +221,6 @@
       "cycads"
     ],
     "egg_laying_interval": 14,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 5500.0,
@@ -261,7 +253,6 @@
       "meat"
     ],
     "egg_laying_interval": 20,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 8000.0,

--- a/dinosurvival/dino_stats_morrison.yaml
+++ b/dinosurvival/dino_stats_morrison.yaml
@@ -16,7 +16,6 @@
       "meat"
     ],
     "egg_laying_interval": 10,
-    "forms_packs": true,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 3000.0,
@@ -47,7 +46,6 @@
       "conifers"
     ],
     "egg_laying_interval": 10,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 12000.0,
@@ -76,7 +74,6 @@
       "cycads"
     ],
     "egg_laying_interval": 10,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 6000.0,
@@ -106,7 +103,6 @@
       "ferns"
     ],
     "egg_laying_interval": 10,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 350.0,
@@ -135,7 +131,6 @@
       "meat"
     ],
     "egg_laying_interval": 10,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 4.0,
     "hp": 900.0,
@@ -164,7 +159,6 @@
       "cycads"
     ],
     "egg_laying_interval": 10,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 8000.0,
@@ -192,7 +186,6 @@
       "fruits"
     ],
     "egg_laying_interval": 8,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 40.0,
@@ -225,7 +218,6 @@
       "ferns"
     ],
     "egg_laying_interval": 10,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 600.0,
@@ -253,7 +245,6 @@
       "fruits"
     ],
     "egg_laying_interval": 10,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 5.0,
@@ -281,7 +272,6 @@
       "meat"
     ],
     "egg_laying_interval": 10,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 20.0,
@@ -314,7 +304,6 @@
       "cycads"
     ],
     "egg_laying_interval": 10,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 3000.0,
@@ -346,7 +335,6 @@
       "meat"
     ],
     "egg_laying_interval": 10,
-    "forms_packs": false,
     "growth_rate": 0.35,
     "health_regen": 2.5,
     "hp": 2800.0,

--- a/dinosurvival/dinosaur.py
+++ b/dinosurvival/dinosaur.py
@@ -37,7 +37,6 @@ class DinosaurStats:
     hydration: float = 100.0
     hydration_drain: float = 0.0
     aquatic_boost: float = 0.0
-    forms_packs: bool = False
     mated: bool = False
     turns_until_lay_eggs: int = 0
     diet: list[Diet] = field(default_factory=list)


### PR DESCRIPTION
## Summary
- delete Pack Up logic from game engine
- strip pack buttons and helpers from the GUI
- drop `forms_packs` property from dinosaur data and stats
- restore YAML stats removed inadvertently

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868192f204c832e9273a7e654af48ef