### PR TITLE
Fix Java run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ mvn -f java/pom.xml package
 
 ### Running
 
+The build creates a versioned jar under `java/target`. Run it using
+
 ```bash
-java -cp java/target/dino-survival.jar com.dinosurvival.ui.Main
+java -jar java/target/dino-survival-0.1.0.jar
 ```


### PR DESCRIPTION
## Summary
- fix README instructions for running the Java version

## Testing
- `pytest -q` *(fails: json.decoder.JSONDecodeError)*

------
https://chatgpt.com/codex/tasks/task_e_686a6b621b88832eaa0ed939b23dd19d