### PR TITLE
Mirror Python dataclasses in Java models

### DIFF
--- a/java/src/main/java/com/dinosurvival/model/Diet.java
+++ b/java/src/main/java/com/dinosurvival/model/Diet.java
@@ -1,7 +1,20 @@
 package com.dinosurvival.model;
 
 public enum Diet {
-    HERBIVORE,
-    CARNIVORE,
-    OMNIVORE;
+    MEAT("meat"),
+    INSECTS("insects"),
+    FERNS("ferns"),
+    CYCADS("cycads"),
+    CONIFERS("conifers"),
+    FRUITS("fruits");
+
+    private final String value;
+
+    Diet(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
 }

--- a/java/src/main/java/com/dinosurvival/model/DinosaurStats.java
+++ b/java/src/main/java/com/dinosurvival/model/DinosaurStats.java
@@ -1,40 +1,307 @@
 package com.dinosurvival.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Mirrors the fields of the Python {@code DinosaurStats} dataclass so that
+ * Java code can manipulate the same data easily.
+ */
 public class DinosaurStats {
-    private int health;
-    private int attack;
-    private int defense;
-    private Diet diet;
 
-    public int getHealth() {
-        return health;
+    private String name;
+    private int growthStages;
+
+    private double hatchlingWeight = 0.0;
+    private double adultWeight = 0.0;
+    private double hatchlingAttack = 0.0;
+    private double adultAttack = 0.0;
+    private double hatchlingHp = 0.0;
+    private double adultHp = 0.0;
+    private double hatchlingSpeed = 0.0;
+    private double adultSpeed = 0.0;
+    private double hatchlingEnergyDrain = 0.0;
+    private double adultEnergyDrain = 0.0;
+    private double growthRate = 0.35;
+    private double walkingEnergyDrainMultiplier = 1.0;
+
+    private double attack = 0.0;
+    private double maxHp = 100.0;
+    private double hp = 100.0;
+    private double speed = 0.0;
+    private double energy = 100.0;
+    private double weight = 0.0;
+    private double healthRegen = 0.0;
+    private double hydration = 100.0;
+    private double hydrationDrain = 0.0;
+    private double aquaticBoost = 0.0;
+    private boolean mated = false;
+    private int turnsUntilLayEggs = 0;
+    private List<Diet> diet = new ArrayList<>();
+    private List<String> abilities = new ArrayList<>();
+    private int ambushStreak = 0;
+    private int bleeding = 0;
+    private int brokenBone = 0;
+
+    public DinosaurStats() {
+        // default constructor
     }
 
-    public void setHealth(int health) {
-        this.health = health;
+    /* Helper methods matching the Python dataclass */
+    public boolean isExhausted() {
+        return energy <= 0;
     }
 
-    public int getAttack() {
+    public boolean isDehydrated() {
+        return hydration <= 0;
+    }
+
+    // Getters and setters
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getGrowthStages() {
+        return growthStages;
+    }
+
+    public void setGrowthStages(int growthStages) {
+        this.growthStages = growthStages;
+    }
+
+    public double getHatchlingWeight() {
+        return hatchlingWeight;
+    }
+
+    public void setHatchlingWeight(double hatchlingWeight) {
+        this.hatchlingWeight = hatchlingWeight;
+    }
+
+    public double getAdultWeight() {
+        return adultWeight;
+    }
+
+    public void setAdultWeight(double adultWeight) {
+        this.adultWeight = adultWeight;
+    }
+
+    public double getHatchlingAttack() {
+        return hatchlingAttack;
+    }
+
+    public void setHatchlingAttack(double hatchlingAttack) {
+        this.hatchlingAttack = hatchlingAttack;
+    }
+
+    public double getAdultAttack() {
+        return adultAttack;
+    }
+
+    public void setAdultAttack(double adultAttack) {
+        this.adultAttack = adultAttack;
+    }
+
+    public double getHatchlingHp() {
+        return hatchlingHp;
+    }
+
+    public void setHatchlingHp(double hatchlingHp) {
+        this.hatchlingHp = hatchlingHp;
+    }
+
+    public double getAdultHp() {
+        return adultHp;
+    }
+
+    public void setAdultHp(double adultHp) {
+        this.adultHp = adultHp;
+    }
+
+    public double getHatchlingSpeed() {
+        return hatchlingSpeed;
+    }
+
+    public void setHatchlingSpeed(double hatchlingSpeed) {
+        this.hatchlingSpeed = hatchlingSpeed;
+    }
+
+    public double getAdultSpeed() {
+        return adultSpeed;
+    }
+
+    public void setAdultSpeed(double adultSpeed) {
+        this.adultSpeed = adultSpeed;
+    }
+
+    public double getHatchlingEnergyDrain() {
+        return hatchlingEnergyDrain;
+    }
+
+    public void setHatchlingEnergyDrain(double hatchlingEnergyDrain) {
+        this.hatchlingEnergyDrain = hatchlingEnergyDrain;
+    }
+
+    public double getAdultEnergyDrain() {
+        return adultEnergyDrain;
+    }
+
+    public void setAdultEnergyDrain(double adultEnergyDrain) {
+        this.adultEnergyDrain = adultEnergyDrain;
+    }
+
+    public double getGrowthRate() {
+        return growthRate;
+    }
+
+    public void setGrowthRate(double growthRate) {
+        this.growthRate = growthRate;
+    }
+
+    public double getWalkingEnergyDrainMultiplier() {
+        return walkingEnergyDrainMultiplier;
+    }
+
+    public void setWalkingEnergyDrainMultiplier(double walkingEnergyDrainMultiplier) {
+        this.walkingEnergyDrainMultiplier = walkingEnergyDrainMultiplier;
+    }
+
+    public double getAttack() {
         return attack;
     }
 
-    public void setAttack(int attack) {
+    public void setAttack(double attack) {
         this.attack = attack;
     }
 
-    public int getDefense() {
-        return defense;
+    public double getMaxHp() {
+        return maxHp;
     }
 
-    public void setDefense(int defense) {
-        this.defense = defense;
+    public void setMaxHp(double maxHp) {
+        this.maxHp = maxHp;
     }
 
-    public Diet getDiet() {
+    public double getHp() {
+        return hp;
+    }
+
+    public void setHp(double hp) {
+        this.hp = hp;
+    }
+
+    public double getSpeed() {
+        return speed;
+    }
+
+    public void setSpeed(double speed) {
+        this.speed = speed;
+    }
+
+    public double getEnergy() {
+        return energy;
+    }
+
+    public void setEnergy(double energy) {
+        this.energy = energy;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public void setWeight(double weight) {
+        this.weight = weight;
+    }
+
+    public double getHealthRegen() {
+        return healthRegen;
+    }
+
+    public void setHealthRegen(double healthRegen) {
+        this.healthRegen = healthRegen;
+    }
+
+    public double getHydration() {
+        return hydration;
+    }
+
+    public void setHydration(double hydration) {
+        this.hydration = hydration;
+    }
+
+    public double getHydrationDrain() {
+        return hydrationDrain;
+    }
+
+    public void setHydrationDrain(double hydrationDrain) {
+        this.hydrationDrain = hydrationDrain;
+    }
+
+    public double getAquaticBoost() {
+        return aquaticBoost;
+    }
+
+    public void setAquaticBoost(double aquaticBoost) {
+        this.aquaticBoost = aquaticBoost;
+    }
+
+    public boolean isMated() {
+        return mated;
+    }
+
+    public void setMated(boolean mated) {
+        this.mated = mated;
+    }
+
+    public int getTurnsUntilLayEggs() {
+        return turnsUntilLayEggs;
+    }
+
+    public void setTurnsUntilLayEggs(int turnsUntilLayEggs) {
+        this.turnsUntilLayEggs = turnsUntilLayEggs;
+    }
+
+    public List<Diet> getDiet() {
         return diet;
     }
 
-    public void setDiet(Diet diet) {
+    public void setDiet(List<Diet> diet) {
         this.diet = diet;
+    }
+
+    public List<String> getAbilities() {
+        return abilities;
+    }
+
+    public void setAbilities(List<String> abilities) {
+        this.abilities = abilities;
+    }
+
+    public int getAmbushStreak() {
+        return ambushStreak;
+    }
+
+    public void setAmbushStreak(int ambushStreak) {
+        this.ambushStreak = ambushStreak;
+    }
+
+    public int getBleeding() {
+        return bleeding;
+    }
+
+    public void setBleeding(int bleeding) {
+        this.bleeding = bleeding;
+    }
+
+    public int getBrokenBone() {
+        return brokenBone;
+    }
+
+    public void setBrokenBone(int brokenBone) {
+        this.brokenBone = brokenBone;
     }
 }

--- a/java/src/main/java/com/dinosurvival/model/NPCAnimal.java
+++ b/java/src/main/java/com/dinosurvival/model/NPCAnimal.java
@@ -1,8 +1,52 @@
 package com.dinosurvival.model;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * State for a non-player animal present on the map. Mirrors the Python
+ * {@code NPCAnimal} dataclass.
+ */
 public class NPCAnimal {
+
+    private int id;
     private String name;
-    private DinosaurStats stats;
+    private String sex;
+    private double weight = 0.0;
+    private int age = 0;
+    private double energy = 100.0;
+    private double maxHp = 100.0;
+    private double hp = 100.0;
+    private boolean alive = true;
+    private double attack = 0.0;
+    private double speed = 0.0;
+    private String nextMove = "None";
+    private int turnsUntilLayEggs = 0;
+    private Map<String, Integer> hunts = new HashMap<>();
+    private int eggClustersEaten = 0;
+    private boolean isDescendant = false;
+    private List<String> abilities = new ArrayList<>();
+    private int ambushStreak = 0;
+    private String lastAction = "None";
+    private int bleeding = 0;
+    private int brokenBone = 0;
+    private int bleedWaitTarget = -1;
+    private int bleedWaitTurns = 0;
+
+    public NPCAnimal() {
+        // default constructor
+    }
+
+    // Getters and setters
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
 
     public String getName() {
         return name;
@@ -12,11 +56,171 @@ public class NPCAnimal {
         this.name = name;
     }
 
-    public DinosaurStats getStats() {
-        return stats;
+    public String getSex() {
+        return sex;
     }
 
-    public void setStats(DinosaurStats stats) {
-        this.stats = stats;
+    public void setSex(String sex) {
+        this.sex = sex;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public void setWeight(double weight) {
+        this.weight = weight;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public double getEnergy() {
+        return energy;
+    }
+
+    public void setEnergy(double energy) {
+        this.energy = energy;
+    }
+
+    public double getMaxHp() {
+        return maxHp;
+    }
+
+    public void setMaxHp(double maxHp) {
+        this.maxHp = maxHp;
+    }
+
+    public double getHp() {
+        return hp;
+    }
+
+    public void setHp(double hp) {
+        this.hp = hp;
+    }
+
+    public boolean isAlive() {
+        return alive;
+    }
+
+    public void setAlive(boolean alive) {
+        this.alive = alive;
+    }
+
+    public double getAttack() {
+        return attack;
+    }
+
+    public void setAttack(double attack) {
+        this.attack = attack;
+    }
+
+    public double getSpeed() {
+        return speed;
+    }
+
+    public void setSpeed(double speed) {
+        this.speed = speed;
+    }
+
+    public String getNextMove() {
+        return nextMove;
+    }
+
+    public void setNextMove(String nextMove) {
+        this.nextMove = nextMove;
+    }
+
+    public int getTurnsUntilLayEggs() {
+        return turnsUntilLayEggs;
+    }
+
+    public void setTurnsUntilLayEggs(int turnsUntilLayEggs) {
+        this.turnsUntilLayEggs = turnsUntilLayEggs;
+    }
+
+    public Map<String, Integer> getHunts() {
+        return hunts;
+    }
+
+    public void setHunts(Map<String, Integer> hunts) {
+        this.hunts = hunts;
+    }
+
+    public int getEggClustersEaten() {
+        return eggClustersEaten;
+    }
+
+    public void setEggClustersEaten(int eggClustersEaten) {
+        this.eggClustersEaten = eggClustersEaten;
+    }
+
+    public boolean isDescendant() {
+        return isDescendant;
+    }
+
+    public void setDescendant(boolean descendant) {
+        isDescendant = descendant;
+    }
+
+    public List<String> getAbilities() {
+        return abilities;
+    }
+
+    public void setAbilities(List<String> abilities) {
+        this.abilities = abilities;
+    }
+
+    public int getAmbushStreak() {
+        return ambushStreak;
+    }
+
+    public void setAmbushStreak(int ambushStreak) {
+        this.ambushStreak = ambushStreak;
+    }
+
+    public String getLastAction() {
+        return lastAction;
+    }
+
+    public void setLastAction(String lastAction) {
+        this.lastAction = lastAction;
+    }
+
+    public int getBleeding() {
+        return bleeding;
+    }
+
+    public void setBleeding(int bleeding) {
+        this.bleeding = bleeding;
+    }
+
+    public int getBrokenBone() {
+        return brokenBone;
+    }
+
+    public void setBrokenBone(int brokenBone) {
+        this.brokenBone = brokenBone;
+    }
+
+    public int getBleedWaitTarget() {
+        return bleedWaitTarget;
+    }
+
+    public void setBleedWaitTarget(int bleedWaitTarget) {
+        this.bleedWaitTarget = bleedWaitTarget;
+    }
+
+    public int getBleedWaitTurns() {
+        return bleedWaitTurns;
+    }
+
+    public void setBleedWaitTurns(int bleedWaitTurns) {
+        this.bleedWaitTurns = bleedWaitTurns;
     }
 }

--- a/java/src/main/java/com/dinosurvival/model/Plant.java
+++ b/java/src/main/java/com/dinosurvival/model/Plant.java
@@ -1,8 +1,16 @@
 package com.dinosurvival.model;
 
+/**
+ * A plant instance present on the map. Mirrors the Python {@code Plant} dataclass.
+ */
 public class Plant {
+
     private String name;
-    private PlantStats stats;
+    private double weight;
+
+    public Plant() {
+        // default constructor
+    }
 
     public String getName() {
         return name;
@@ -12,11 +20,11 @@ public class Plant {
         this.name = name;
     }
 
-    public PlantStats getStats() {
-        return stats;
+    public double getWeight() {
+        return weight;
     }
 
-    public void setStats(PlantStats stats) {
-        this.stats = stats;
+    public void setWeight(double weight) {
+        this.weight = weight;
     }
 }

--- a/java/src/main/java/com/dinosurvival/model/PlantStats.java
+++ b/java/src/main/java/com/dinosurvival/model/PlantStats.java
@@ -1,22 +1,62 @@
 package com.dinosurvival.model;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mirrors the Python {@code PlantStats} dataclass.
+ */
 public class PlantStats {
-    private int nutrition;
-    private int growthRate;
 
-    public int getNutrition() {
-        return nutrition;
+    private String name;
+    private List<String> formations = new ArrayList<>();
+    private String image;
+    private double weight;
+    private Map<String, Double> growthChance = new HashMap<>();
+
+    public PlantStats() {
+        // default constructor
     }
 
-    public void setNutrition(int nutrition) {
-        this.nutrition = nutrition;
+    public String getName() {
+        return name;
     }
 
-    public int getGrowthRate() {
-        return growthRate;
+    public void setName(String name) {
+        this.name = name;
     }
 
-    public void setGrowthRate(int growthRate) {
-        this.growthRate = growthRate;
+    public List<String> getFormations() {
+        return formations;
+    }
+
+    public void setFormations(List<String> formations) {
+        this.formations = formations;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public void setWeight(double weight) {
+        this.weight = weight;
+    }
+
+    public Map<String, Double> getGrowthChance() {
+        return growthChance;
+    }
+
+    public void setGrowthChance(Map<String, Double> growthChance) {
+        this.growthChance = growthChance;
     }
 }


### PR DESCRIPTION
## Summary
- expand Diet enum with categories from the Python code
- implement full DinosaurStats model matching dinosurvival/dinosaur.py
- implement NPCAnimal model mirroring Python dataclass
- implement PlantStats and Plant models based on plant.py

## Testing
- `pytest -q` *(fails: JSONDecodeError)*

------
https://chatgpt.com/codex/tasks/task_e_686a6e59f420832e87f37a173cae83d1