### PR TITLE
Fix Java build and YAML parsing

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,12 +8,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.15.2</version>
+            <version>2.8.11</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.0</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -22,11 +22,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>17</source>
                     <target>17</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -43,7 +48,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>2.22.3</version>
             </plugin>
         </plugins>
     </build>

--- a/java/src/main/java/com/dinosurvival/util/StatsLoader.java
+++ b/java/src/main/java/com/dinosurvival/util/StatsLoader.java
@@ -4,7 +4,9 @@ import com.dinosurvival.model.Diet;
 import com.dinosurvival.model.DinosaurStats;
 import com.dinosurvival.model.PlantStats;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.IOException;
 import java.io.InputStream;
@@ -21,7 +23,9 @@ import java.util.Map;
  */
 public class StatsLoader {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+    private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
     private static final int HATCHLING_WEIGHT_DIVISOR = 1000;
     private static final int HATCHLING_SPEED_MULTIPLIER = 3;

--- a/java/src/main/java/com/dinosurvival/util/YamlLoader.java
+++ b/java/src/main/java/com/dinosurvival/util/YamlLoader.java
@@ -1,13 +1,17 @@
 package com.dinosurvival.util;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.IOException;
 import java.io.InputStream;
 
 public class YamlLoader {
-    private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+    private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
     public static <T> T load(InputStream in, Class<T> clazz) throws IOException {
         return MAPPER.readValue(in, clazz);


### PR DESCRIPTION
## Summary
- update dependencies in the Maven build file to use versions available in the environment
- add maven-resources-plugin configuration
- allow Jackson to ignore unknown fields and use snake case names in YAML utilities

## Testing
- `mvn -Dmaven.repo.local=/usr/share/maven-repo test`

------
https://chatgpt.com/codex/tasks/task_e_686aa4c07fa0832ead04c64fe544e1e8