### PR TITLE
Fix missing Jackson dependency

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,6 +11,11 @@
             <version>2.8.11</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.11</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.10.1</version>


### PR DESCRIPTION
## Summary
- add missing Jackson databind dependency for StatsLoader and YamlLoader

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.0 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686ab22a3228832eb7c438ad56e33e08