### PR TITLE
Fix Java build and YAML data

### DIFF
--- a/dinosurvival/critter_stats_hell_creek.yaml
+++ b/dinosurvival/critter_stats_hell_creek.yaml
@@ -2,7 +2,7 @@
   "Avisaurus": {
     "abilities": [
       "flight"
-    ]
+    ],
     "adult_speed": 140,
     "adult_weight": 1.7,
     "aggressive": false,

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,12 +8,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.8.11</version>
+            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.11</version>
+            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- update Jackson dependencies to 2.19.0
- correct typo in critter stats YAML so it parses

## Testing
- `mvn -DskipTests compile`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab7fc450c832e8c2febd793bfdd08