### PR TITLE
Port biome map logic to Java

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/LavaInfo.java
+++ b/java/src/main/java/com/dinosurvival/game/LavaInfo.java
@@ -1,0 +1,28 @@
+package com.dinosurvival.game;
+
+/** Simple holder for lava spread state. */
+public class LavaInfo {
+    private int steps;
+    private int cooldown;
+
+    public LavaInfo(int steps, int cooldown) {
+        this.steps = steps;
+        this.cooldown = cooldown;
+    }
+
+    public int getSteps() {
+        return steps;
+    }
+
+    public void setSteps(int steps) {
+        this.steps = steps;
+    }
+
+    public int getCooldown() {
+        return cooldown;
+    }
+
+    public void setCooldown(int cooldown) {
+        this.cooldown = cooldown;
+    }
+}

--- a/java/src/main/java/com/dinosurvival/game/Terrain.java
+++ b/java/src/main/java/com/dinosurvival/game/Terrain.java
@@ -1,8 +1,36 @@
 package com.dinosurvival.game;
 
 public enum Terrain {
-    FOREST,
-    PLAIN,
-    SWAMP,
-    DESERT
+    DESERT("desert"),
+    DESERT_FLOODED("desert_flooded"),
+    TOXIC_BADLANDS("toxic_badlands"),
+    PLAINS("plains"),
+    PLAINS_FLOODED("plains_flooded"),
+    WOODLANDS("woodlands"),
+    WOODLANDS_FLOODED("woodlands_flooded"),
+    FOREST("forest"),
+    FOREST_FLOODED("forest_flooded"),
+    FOREST_FIRE("forest_fire"),
+    FOREST_BURNT("forest_burnt"),
+    HIGHLAND_FOREST("highland_forest"),
+    HIGHLAND_FOREST_FIRE("highland_forest_fire"),
+    HIGHLAND_FOREST_BURNT("highland_forest_burnt"),
+    SWAMP("swamp"),
+    SWAMP_FLOODED("swamp_flooded"),
+    LAKE("lake"),
+    MOUNTAIN("mountain"),
+    VOLCANO("volcano"),
+    VOLCANO_ERUPTING("volcano_erupting"),
+    LAVA("lava"),
+    SOLIDIFIED_LAVA_FIELD("solidified_lava_field");
+
+    private final String name;
+
+    Terrain(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
 }


### PR DESCRIPTION
## Summary
- enrich `Terrain` enum with new biome names and helper
- implement Java `Map` class with noise-based biome generation and simple
  volcano/fire handling
- add `LavaInfo` helper class
- keep existing tests working

## Testing
- `mvn -f java/pom.xml test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab9b67c5c832e90677dcbf447ed8a