### PR TITLE
Implement NPC spawning logic in Java

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -165,19 +165,28 @@ public class Game {
 
     /** Populate the map with initial dinosaur NPCs. */
     private void _populateAnimals() {
+        List<int[]> land = new ArrayList<>();
+        for (int ty = 0; ty < map.getHeight(); ty++) {
+            for (int tx = 0; tx < map.getWidth(); tx++) {
+                Terrain t = map.terrainAt(tx, ty);
+                if (t != Terrain.LAKE && t != Terrain.TOXIC_BADLANDS) {
+                    land.add(new int[]{tx, ty});
+                }
+            }
+        }
+
         Random r = new Random();
         StatsLoader.getDinoStats().forEach((name, stats) -> {
-            int count = (int) Math.max(1, stats.getAdultWeight() / 1000);
-            for (int i = 0; i < count; i++) {
-                int ax = r.nextInt(map.getWidth());
-                int ay = r.nextInt(map.getHeight());
+            int spawnCount = (int) Math.max(1, stats.getAdultWeight() / 1000);
+            for (int i = 0; i < spawnCount && !land.isEmpty(); i++) {
+                int[] pos = land.get(r.nextInt(land.size()));
                 NPCAnimal npc = new NPCAnimal();
-                npc.setId(spawned.size() + 1);
+                npc.setId(nextNpcId++);
                 npc.setName(name);
                 npc.setWeight(stats.getAdultWeight());
                 npc.setMaxHp(stats.getAdultHp());
                 npc.setHp(npc.getMaxHp());
-                map.addAnimal(ax, ay, npc);
+                map.addAnimal(pos[0], pos[1], npc);
                 spawned.add(npc);
             }
         });
@@ -188,34 +197,87 @@ public class Game {
         if (StatsLoader.getCritterStats().isEmpty()) {
             return;
         }
+
         List<int[]> land = new ArrayList<>();
         List<int[]> lake = new ArrayList<>();
-        for (int y = 0; y < map.getHeight(); y++) {
-            for (int x = 0; x < map.getWidth(); x++) {
-                Terrain t = map.terrainAt(x, y);
+        for (int ty = 0; ty < map.getHeight(); ty++) {
+            for (int tx = 0; tx < map.getWidth(); tx++) {
+                Terrain t = map.terrainAt(tx, ty);
                 if (t == Terrain.LAKE) {
-                    lake.add(new int[]{x, y});
+                    lake.add(new int[]{tx, ty});
                 } else if (t != Terrain.TOXIC_BADLANDS) {
-                    land.add(new int[]{x, y});
+                    land.add(new int[]{tx, ty});
                 }
             }
         }
+
         Random r = new Random();
         StatsLoader.getCritterStats().forEach((name, stats) -> {
+            int maxInd = 0;
             Object maxObj = stats.get("maximum_individuals");
-            int maxInd = maxObj instanceof Number ? ((Number) maxObj).intValue() : 0;
-            int spawnCount = initial ? maxInd / 2 : 0;
+            if (maxObj instanceof Number num) {
+                maxInd = num.intValue();
+            }
+
+            int current = 0;
+            for (int y = 0; y < map.getHeight(); y++) {
+                for (int x = 0; x < map.getWidth(); x++) {
+                    for (NPCAnimal npc : map.getAnimals(x, y)) {
+                        if (name.equals(npc.getName())) {
+                            current++;
+                        }
+                    }
+                }
+            }
+
+            int available = Math.max(0, maxInd - current);
+            int spawnCount;
+            if (initial) {
+                spawnCount = maxInd / 2;
+            } else {
+                double avg = 0.0;
+                Object avgObj = stats.get("avg_spawned_per_turn");
+                if (avgObj instanceof Number num) {
+                    avg = num.doubleValue();
+                }
+                spawnCount = (int) Math.round(r.nextGaussian() * 0.5 + avg);
+                if (spawnCount < 0) spawnCount = 0;
+            }
+
+            int toSpawn = Math.min(spawnCount, available);
             boolean canWalk = !Boolean.FALSE.equals(stats.get("can_walk"));
             List<int[]> tiles = canWalk ? land : lake;
-            for (int i = 0; i < spawnCount && !tiles.isEmpty(); i++) {
+
+            for (int i = 0; i < toSpawn && !tiles.isEmpty(); i++) {
                 int[] pos = tiles.get(r.nextInt(tiles.size()));
+
+                boolean occupied = false;
+                for (NPCAnimal npc : map.getAnimals(pos[0], pos[1])) {
+                    if (name.equals(npc.getName())) {
+                        occupied = true;
+                        break;
+                    }
+                }
+                if (occupied) {
+                    continue;
+                }
+
                 NPCAnimal npc = new NPCAnimal();
                 npc.setId(nextNpcId++);
                 npc.setName(name);
-                double weight = stats.get("adult_weight") instanceof Number
-                        ? ((Number) stats.get("adult_weight")).doubleValue() : 0.0;
-                double hp = stats.get("hp") instanceof Number
-                        ? ((Number) stats.get("hp")).doubleValue() : 0.0;
+
+                double weight = 0.0;
+                Object wObj = stats.get("adult_weight");
+                if (wObj instanceof Number num) {
+                    weight = num.doubleValue();
+                }
+
+                double hp = 0.0;
+                Object hpObj = stats.get("hp");
+                if (hpObj instanceof Number num) {
+                    hp = num.doubleValue();
+                }
+
                 npc.setWeight(weight);
                 npc.setMaxHp(hp);
                 npc.setHp(hp);


### PR DESCRIPTION
## Summary
- enhance Java `Game` class NPC population
- add random distribution for animal and critter spawning
- respect population caps and movement abilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac3a861c0832e8739b38771bdaecf