### PR TITLE
Add encounter generation and aggressive NPC check in Java game

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Map.java
+++ b/java/src/main/java/com/dinosurvival/game/Map.java
@@ -342,6 +342,20 @@ public class Map {
         animals[y][x].remove(npc);
     }
 
+    /**
+     * Get the list of egg clusters present at the given coordinates.
+     */
+    public List<EggCluster> getEggs(int x, int y) {
+        return eggs[y][x];
+    }
+
+    /**
+     * Get the list of plants present at the given coordinates.
+     */
+    public List<Plant> getPlants(int x, int y) {
+        return plants[y][x];
+    }
+
     // ---------------------------------------------------------------------
     // Minimal implementations of dynamic map effects. These are greatly
     // simplified compared to the Python version but allow tests to invoke


### PR DESCRIPTION
## Summary
- expose eggs and plants from `Map`
- track encounters on the player's tile in `Game`
- compute aggressive NPC attacks when starting turns

## Testing
- `mvn test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac56a1330832ea9059cb5e86eab92