### PR TITLE
Fix NPC movement stats lookup

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -907,7 +907,9 @@ public class Game {
                     "Down", new int[]{0,1}, "Left", new int[]{-1,0});
             for (NPCAnimal npc : weaker) {
                 List<String> opts = new ArrayList<>();
-                boolean canWalk = !getBool(StatsLoader.getDinoStats().getOrDefault(npc.getName(), StatsLoader.getCritterStats().get(npc.getName())), "can_walk", true) ? false : true;
+                Object stats = StatsLoader.getDinoStats().get(npc.getName());
+                if (stats == null) stats = StatsLoader.getCritterStats().get(npc.getName());
+                boolean canWalk = !getBool(stats, "can_walk", true) ? false : true;
                 for (var e : dirs.entrySet()) {
                     int nx = x + e.getValue()[0];
                     int ny = y + e.getValue()[1];


### PR DESCRIPTION
## Summary
- handle missing NPC stats when determining walking ability
- resolve compilation failure for mixed stat types

## Testing
- `mvn -f java/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_686ad4915028832ebfb4703822ca5d1d