### PR TITLE
Implement missing egg helpers in Java Map

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Map.java
+++ b/java/src/main/java/com/dinosurvival/game/Map.java
@@ -351,6 +351,24 @@ public class Map {
     }
 
     /**
+     * Remove and return the first egg cluster from the cell, if any.
+     */
+    public EggCluster takeEggs(int x, int y) {
+        List<EggCluster> cell = eggs[y][x];
+        if (!cell.isEmpty()) {
+            return cell.remove(0);
+        }
+        return null;
+    }
+
+    /**
+     * Add an egg cluster to the specified cell.
+     */
+    public void addEggs(int x, int y, EggCluster cluster) {
+        eggs[y][x].add(cluster);
+    }
+
+    /**
      * Get the list of plants present at the given coordinates.
      */
     public List<Plant> getPlants(int x, int y) {


### PR DESCRIPTION
## Summary
- add `takeEggs` and `addEggs` to the Java `Map` class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae0c8a06c832e8b8255e9602a8381