### PR TITLE
Fix cross-platform test setup

### DIFF
--- a/java/src/test/java/com/dinosurvival/GameTest.java
+++ b/java/src/test/java/com/dinosurvival/GameTest.java
@@ -15,9 +15,9 @@ import org.junit.jupiter.api.Test;
 public class GameTest {
     @BeforeAll
     public static void setup() throws Exception {
-        Path link = Path.of("dinosurvival");
-        if (!Files.exists(link)) {
-            Files.createSymbolicLink(link, Path.of("..", "dinosurvival"));
+        Path base = Path.of("..", "dinosurvival");
+        if (Files.exists(base)) {
+            StatsLoader.load(base, "Morrison");
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid using a symbolic link in GameTest so tests run on Windows too

## Testing
- `mvn -f java/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_686ae649e268832eae83f3a1cbd61331