### PR TITLE
Add plant UI and button logic

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -1399,6 +1399,20 @@ public class Game {
         return turn;
     }
 
+    /**
+     * Return true if the player can currently lay eggs.
+     */
+    public boolean playerCanLayEggs() {
+        return canPlayerLayEggs();
+    }
+
+    /**
+     * Get the list of plants on the player's current tile.
+     */
+    public java.util.List<Plant> getCurrentPlants() {
+        return currentPlants;
+    }
+
     public boolean hasWon() {
         return won;
     }


### PR DESCRIPTION
## Summary
- build 3×3 button grid with drink and lay eggs actions
- add plant panel showing images and weights from `StatsLoader`
- enable or disable Lay Eggs and Drink based on game state
- expose helper methods in `Game` for UI

## Testing
- `mvn -f java/pom.xml -DskipTests compile`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686afdc45914832ebeab842c9d64e0db