### PR TITLE
Add encounter panel to Java UI

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -1407,6 +1407,47 @@ public class Game {
     }
 
     /**
+     * Get the list of encounters on the player's current tile.
+     */
+    public java.util.List<EncounterEntry> getCurrentEncounters() {
+        return currentEncounters;
+    }
+
+    /**
+     * Effective attack value for the given NPC.
+     */
+    public double npcEffectiveAttack(NPCAnimal npc) {
+        Object stats = StatsLoader.getDinoStats().get(npc.getName());
+        if (stats == null) {
+            stats = StatsLoader.getCritterStats().get(npc.getName());
+        }
+        return npcEffectiveAttack(npc, stats, x, y);
+    }
+
+    /**
+     * Effective speed value for the given NPC.
+     */
+    public double npcEffectiveSpeed(NPCAnimal npc) {
+        Object stats = StatsLoader.getDinoStats().get(npc.getName());
+        if (stats == null) {
+            stats = StatsLoader.getCritterStats().get(npc.getName());
+        }
+        return npcEffectiveSpeed(npc, stats);
+    }
+
+    /**
+     * Maximum health for the given NPC based on its weight.
+     */
+    public double npcMaxHp(NPCAnimal npc) {
+        Object stats = StatsLoader.getDinoStats().get(npc.getName());
+        if (stats == null) {
+            stats = StatsLoader.getCritterStats().get(npc.getName());
+        }
+        return scaleByWeight(npc.getWeight(), getStat(stats, "adult_weight"),
+                getStat(stats, "hp"));
+    }
+
+    /**
      * Get the list of plants on the player's current tile.
      */
     public java.util.List<Plant> getCurrentPlants() {

--- a/java/src/main/java/com/dinosurvival/ui/NpcStatsDialog.java
+++ b/java/src/main/java/com/dinosurvival/ui/NpcStatsDialog.java
@@ -1,0 +1,35 @@
+package com.dinosurvival.ui;
+
+import com.dinosurvival.game.Game;
+import com.dinosurvival.model.NPCAnimal;
+
+import javax.swing.*;
+import java.awt.BorderLayout;
+
+/** Simple dialog showing NPC statistics. */
+public class NpcStatsDialog extends JDialog {
+    public NpcStatsDialog(JFrame parent, Game game, NPCAnimal npc) {
+        super(parent, npc.getName() + " Stats", true);
+        JTextArea area = new JTextArea(10, 30);
+        area.setEditable(false);
+        area.setText(buildText(game, npc));
+        add(new JScrollPane(area), BorderLayout.CENTER);
+        JButton close = new JButton("Close");
+        close.addActionListener(e -> dispose());
+        add(close, BorderLayout.SOUTH);
+        pack();
+        setLocationRelativeTo(parent);
+    }
+
+    private String buildText(Game game, NPCAnimal npc) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Name: ").append(npc.getName()).append('\n');
+        sb.append("Age: ").append(npc.getAge()).append(" turns\n");
+        sb.append(String.format("Weight: %.1f\n", npc.getWeight()));
+        sb.append(String.format("HP: %.1f/%.1f\n", npc.getHp(), game.npcMaxHp(npc)));
+        sb.append(String.format("Energy: %.0f%%\n", npc.getEnergy()));
+        sb.append(String.format("Attack: %.1f\n", game.npcEffectiveAttack(npc)));
+        sb.append(String.format("Speed: %.1f\n", game.npcEffectiveSpeed(npc)));
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Summary
- show encounters in GameWindow with scrollable panel
- add NPC stats dialog and actions for hunting or collecting eggs
- expose encounter data from `Game`
- compile Maven project and run Python tests

## Testing
- `mvn -f java/pom.xml package`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686affc283b4832eb30a0ea70496671c