### PR TITLE
Add weather panel and improved biome info

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Map.java
+++ b/java/src/main/java/com/dinosurvival/game/Map.java
@@ -351,6 +351,13 @@ public class Map {
     }
 
     /**
+     * Return {@code true} if any egg clusters are present in the cell.
+     */
+    public boolean hasNest(int x, int y) {
+        return !eggs[y][x].isEmpty();
+    }
+
+    /**
      * Remove and return the first egg cluster from the cell, if any.
      */
     public EggCluster takeEggs(int x, int y) {


### PR DESCRIPTION
## Summary
- display weather info with icon and effects in GameWindow
- show nest and coordinates in biome panel
- provide helper for biome name formatting
- add Map.hasNest helper

## Testing
- `mvn -f java/pom.xml test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b0cab23e8832eade6e4d480dda3f9