### PR TITLE
Add Swing info/help dialogs

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -36,6 +36,7 @@ public class Game {
     private String lastAction = "";
     private final java.util.Map<String, List<Integer>> populationHistory = new java.util.HashMap<>();
     private final List<Integer> turnHistory = new ArrayList<>();
+    private String formation;
 
     /** Number of descendants required to win the game. */
     public static final int DESCENDANTS_TO_WIN = 5;
@@ -57,6 +58,7 @@ public class Game {
     public void start(String formation, String dinoName) {
         try {
             StatsLoader.load(Path.of("dinosurvival"), formation);
+            this.formation = formation;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -1397,6 +1399,10 @@ public class Game {
 
     public int getTurn() {
         return turn;
+    }
+
+    public String getFormation() {
+        return formation;
     }
 
     /**

--- a/java/src/main/java/com/dinosurvival/ui/DinoFactsDialog.java
+++ b/java/src/main/java/com/dinosurvival/ui/DinoFactsDialog.java
@@ -1,0 +1,139 @@
+package com.dinosurvival.ui;
+
+import com.dinosurvival.game.Game;
+import com.dinosurvival.model.DinosaurStats;
+import com.dinosurvival.util.StatsLoader;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/** Dialog displaying facts about a dinosaur or critter. */
+public class DinoFactsDialog extends JDialog {
+    public DinoFactsDialog(JFrame parent, Game game, String name) {
+        super(parent, name + " Facts", true);
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        add(new JScrollPane(panel), BorderLayout.CENTER);
+
+        ImageIcon img = loadScaledIcon(imagePath(name), 400, 250);
+        if (img != null) {
+            JLabel imgLbl = new JLabel(img);
+            imgLbl.setAlignmentX(Component.CENTER_ALIGNMENT);
+            panel.add(imgLbl);
+        }
+        JLabel heading = new JLabel(name);
+        heading.setFont(heading.getFont().deriveFont(Font.BOLD, 18f));
+        heading.setAlignmentX(Component.CENTER_ALIGNMENT);
+        panel.add(heading);
+
+        Object info = StatsLoader.getDinoStats().get(name);
+        boolean isDino = true;
+        if (info == null) {
+            info = StatsLoader.getCritterStats().get(name);
+            isDino = false;
+        }
+        if (info == null) {
+            info = Map.of();
+        }
+
+        if (isDino) {
+            DinosaurStats ds = (DinosaurStats) info;
+            iconLabel(panel, "/assets/icons/weight.png", String.format("%.0f kg", ds.getAdultWeight()));
+            iconLabel(panel, "/assets/icons/attack.png", String.format("%.0f", ds.getAdultAttack()));
+            iconLabel(panel, "/assets/icons/health.png", String.format("%.0f", ds.getAdultHp()));
+            iconLabel(panel, "/assets/icons/speed.png", String.format("%.0f", ds.getAdultSpeed()));
+            iconLabel(panel, "/assets/icons/turn.png", "Energy drain: " + ds.getAdultEnergyDrain());
+            String diet = String.join(", ", ds.getDiet().stream().map(Object::toString).toList());
+            label(panel, "Diet: " + diet);
+            if (!ds.getAbilities().isEmpty()) {
+                label(panel, "Abilities: " + String.join(", ", ds.getAbilities()));
+            }
+        } else if (info instanceof Map<?,?> map) {
+            iconLabel(panel, "/assets/icons/weight.png", String.format("%.0f kg", getDouble(map.get("adult_weight"))));
+            iconLabel(panel, "/assets/icons/attack.png", String.format("%.0f", getDouble(map.get("attack"))));
+            iconLabel(panel, "/assets/icons/health.png", String.format("%.0f", getDouble(map.get("hp"))));
+            iconLabel(panel, "/assets/icons/speed.png", String.format("%.0f", getDouble(map.get("adult_speed"))));
+            iconLabel(panel, "/assets/icons/turn.png", "Energy drain: " + getDouble(map.get("adult_energy_drain")));
+            Object diet = map.get("diet");
+            if (diet instanceof List<?> list && !list.isEmpty()) {
+                label(panel, "Diet: " + String.join(", ", list.stream().map(Object::toString).toList()));
+            }
+            Object abilities = map.get("abilities");
+            if (abilities instanceof List<?> list && !list.isEmpty()) {
+                label(panel, "Abilities: " + String.join(", ", list.stream().map(Object::toString).toList()));
+            }
+        }
+
+        JButton close = new JButton("Close");
+        close.addActionListener(e -> dispose());
+        JPanel btn = new JPanel();
+        btn.add(close);
+        add(btn, BorderLayout.SOUTH);
+        pack();
+        setLocationRelativeTo(parent);
+    }
+
+    private static void label(JPanel panel, String text) {
+        JLabel l = new JLabel(text);
+        l.setAlignmentX(Component.LEFT_ALIGNMENT);
+        panel.add(l);
+    }
+
+    private static void iconLabel(JPanel panel, String iconPath, String text) {
+        JLabel l = new JLabel(text);
+        l.setAlignmentX(Component.LEFT_ALIGNMENT);
+        ImageIcon icon = loadScaledIcon(iconPath, 20, 20);
+        if (icon != null) {
+            l.setIcon(icon);
+        }
+        panel.add(l);
+    }
+
+    private static String imagePath(String name) {
+        String fname = name.toLowerCase().replace(" ", "_") + ".png";
+        return "/assets/dinosaurs/" + fname;
+    }
+
+    private static double getDouble(Object o) {
+        if (o instanceof Number n) {
+            return n.doubleValue();
+        }
+        if (o != null) {
+            try {
+                return Double.parseDouble(o.toString());
+            } catch (NumberFormatException ignored) { }
+        }
+        return 0.0;
+    }
+
+    private static ImageIcon loadScaledIcon(String path, int width, int height) {
+        java.net.URL url = DinoFactsDialog.class.getResource(path);
+        if (url == null) {
+            return null;
+        }
+        try {
+            BufferedImage img = ImageIO.read(url);
+            double scaleW = (double) width / img.getWidth();
+            double scaleH = (double) height / img.getHeight();
+            double scale = Math.max(scaleW, scaleH);
+            int newW = (int) Math.round(img.getWidth() * scale);
+            int newH = (int) Math.round(img.getHeight() * scale);
+            Image scaled = img.getScaledInstance(newW, newH, Image.SCALE_SMOOTH);
+            BufferedImage resized = new BufferedImage(newW, newH, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D g2 = resized.createGraphics();
+            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+            g2.drawImage(scaled, 0, 0, null);
+            g2.dispose();
+            int x = Math.max(0, (newW - width) / 2);
+            int y = Math.max(0, (newH - height) / 2);
+            BufferedImage cropped = resized.getSubimage(x, y, width, height);
+            return new ImageIcon(cropped);
+        } catch (IOException ex) {
+            return null;
+        }
+    }
+}

--- a/java/src/main/java/com/dinosurvival/ui/EncounterHelpDialog.java
+++ b/java/src/main/java/com/dinosurvival/ui/EncounterHelpDialog.java
@@ -1,0 +1,30 @@
+package com.dinosurvival.ui;
+
+import javax.swing.*;
+import java.awt.BorderLayout;
+
+/** Dialog explaining the encounter list columns. */
+public class EncounterHelpDialog extends JDialog {
+    public EncounterHelpDialog(JFrame parent) {
+        super(parent, "Encounter Help", true);
+        setLayout(new BorderLayout());
+        JLabel heading = new JLabel("Encounters", SwingConstants.CENTER);
+        heading.setBorder(BorderFactory.createEmptyBorder(5,5,5,5));
+        add(heading, BorderLayout.NORTH);
+        JTextArea area = new JTextArea();
+        area.setEditable(false);
+        area.setText(String.join("\n",
+                "The encounters list displays animals or nests in your current cell.",
+                "W: prey weight, A: attack power, HP: health points,",
+                "S: speed relative to you (%) and E: energy available.",
+                "Higher attack deals more damage while higher speed",
+                "makes prey harder to catch."));
+        area.setBorder(BorderFactory.createEmptyBorder(5,10,5,10));
+        add(area, BorderLayout.CENTER);
+        JButton close = new JButton("Close");
+        close.addActionListener(e -> dispose());
+        add(close, BorderLayout.SOUTH);
+        pack();
+        setLocationRelativeTo(parent);
+    }
+}

--- a/java/src/main/java/com/dinosurvival/ui/GameHelpDialog.java
+++ b/java/src/main/java/com/dinosurvival/ui/GameHelpDialog.java
@@ -1,0 +1,32 @@
+package com.dinosurvival.ui;
+
+import javax.swing.*;
+import java.awt.BorderLayout;
+
+/** Dialog showing general gameplay help. */
+public class GameHelpDialog extends JDialog {
+    public GameHelpDialog(JFrame parent) {
+        super(parent, "Game Help", true);
+        setLayout(new BorderLayout());
+        JLabel heading = new JLabel("Game Help", SwingConstants.CENTER);
+        heading.setBorder(BorderFactory.createEmptyBorder(5,5,5,5));
+        add(heading, BorderLayout.NORTH);
+        JTextArea area = new JTextArea();
+        area.setEditable(false);
+        area.setText(String.join("\n",
+                "Use the movement buttons to travel north, south, east or west.",
+                "Stay will skip a turn and Drink restores hydration when water is present.",
+                "Threaten can scare prey away. Lay Eggs lets you deposit eggs once ready.",
+                "Lay Eggs requires being fully grown with 80+ health and energy.",
+                "There is a short waiting period before eggs can be laid again after doing so.",
+                "Health, Energy, Hydration, Weight, Attack and Speed describe your dinosaur.",
+                "Grow by hunting prey and once grown up lay eggs and hatch enough of them to win."));
+        area.setBorder(BorderFactory.createEmptyBorder(5,10,5,10));
+        add(area, BorderLayout.CENTER);
+        JButton close = new JButton("Close");
+        close.addActionListener(e -> dispose());
+        add(close, BorderLayout.SOUTH);
+        pack();
+        setLocationRelativeTo(parent);
+    }
+}

--- a/java/src/main/java/com/dinosurvival/ui/GameWindow.java
+++ b/java/src/main/java/com/dinosurvival/ui/GameWindow.java
@@ -7,6 +7,11 @@ import com.dinosurvival.model.PlantStats;
 import com.dinosurvival.game.EncounterEntry;
 import com.dinosurvival.model.NPCAnimal;
 import com.dinosurvival.util.StatsLoader;
+import com.dinosurvival.ui.DinoFactsDialog;
+import com.dinosurvival.ui.GameHelpDialog;
+import com.dinosurvival.ui.EncounterHelpDialog;
+import com.dinosurvival.ui.LegacyStatsDialog;
+import com.dinosurvival.ui.StatsDialog;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -59,6 +64,10 @@ public class GameWindow extends JFrame {
     private final JButton drinkButton = new JButton("Drink");
     private final JButton threatenButton = new JButton("Threaten");
     private final JButton layButton = new JButton("Lay Eggs");
+    private final JButton infoButton = new JButton("Info");
+    private final JButton playerStatsButton = new JButton("Player Stats");
+    private final JButton dinoStatsButton = new JButton("Dinosaur Stats");
+    private final JButton helpButton = new JButton("Help");
 
     private ImageIcon loadScaledIcon(String path, int width, int height) {
         java.net.URL url = getClass().getResource(path);
@@ -124,6 +133,12 @@ public class GameWindow extends JFrame {
         if (dIcon != null) {
             dinoImageLabel.setIcon(dIcon);
         }
+        JPanel infoRow = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        infoRow.add(infoButton);
+        infoRow.add(dinoStatsButton);
+        infoRow.add(playerStatsButton);
+        infoRow.add(helpButton);
+        dinoPanel.add(infoRow, BorderLayout.SOUTH);
         c.gridx = 0;
         c.gridy = 0;
         c.weightx = 0;
@@ -262,9 +277,14 @@ public class GameWindow extends JFrame {
             encounterSortAsc = !encounterSortAsc;
             updateEncounterList();
         });
+        JButton encHelp = new JButton("Help");
+        encHelp.addActionListener(e -> new EncounterHelpDialog(this).setVisible(true));
         JPanel encHeader = new JPanel(new BorderLayout());
         encHeader.add(encLabel, BorderLayout.WEST);
-        encHeader.add(sortBtn, BorderLayout.EAST);
+        JPanel encBtns = new JPanel(new FlowLayout(FlowLayout.RIGHT, 5, 0));
+        encBtns.add(encHelp);
+        encBtns.add(sortBtn);
+        encHeader.add(encBtns, BorderLayout.EAST);
         encounterPanel.add(encHeader, BorderLayout.NORTH);
         encounterList.setLayout(new BoxLayout(encounterList, BoxLayout.Y_AXIS));
         JScrollPane encounterScroll = new JScrollPane(encounterList);
@@ -327,6 +347,10 @@ public class GameWindow extends JFrame {
         drinkButton.addActionListener(e -> doAction(() -> game.drink(), "Drink"));
         threatenButton.addActionListener(e -> doAction(() -> game.threaten(), "Threaten"));
         layButton.addActionListener(e -> doAction(() -> game.layEggs(), "Lay eggs"));
+        infoButton.addActionListener(e -> new DinoFactsDialog(this, game, game.getPlayer().getName()).setVisible(true));
+        playerStatsButton.addActionListener(e -> new StatsDialog(this, game).setVisible(true));
+        dinoStatsButton.addActionListener(e -> new LegacyStatsDialog(this, game.getFormation(), game.getPlayer().getName()).setVisible(true));
+        helpButton.addActionListener(e -> new GameHelpDialog(this).setVisible(true));
 
         buildMap();
         refreshAll();

--- a/java/src/main/java/com/dinosurvival/ui/NpcStatsDialog.java
+++ b/java/src/main/java/com/dinosurvival/ui/NpcStatsDialog.java
@@ -4,32 +4,115 @@ import com.dinosurvival.game.Game;
 import com.dinosurvival.model.NPCAnimal;
 
 import javax.swing.*;
-import java.awt.BorderLayout;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import java.io.IOException;
+import java.util.Map;
 
 /** Simple dialog showing NPC statistics. */
 public class NpcStatsDialog extends JDialog {
     public NpcStatsDialog(JFrame parent, Game game, NPCAnimal npc) {
         super(parent, npc.getName() + " Stats", true);
-        JTextArea area = new JTextArea(10, 30);
-        area.setEditable(false);
-        area.setText(buildText(game, npc));
-        add(new JScrollPane(area), BorderLayout.CENTER);
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        add(new JScrollPane(panel), BorderLayout.CENTER);
+
+        ImageIcon img = loadScaledIcon(imagePath(npc.getName()), 400, 250, !npc.isAlive());
+        if (img != null) {
+            JLabel imgLbl = new JLabel(img);
+            imgLbl.setAlignmentX(Component.CENTER_ALIGNMENT);
+            panel.add(imgLbl);
+        }
+
+        JLabel heading = new JLabel(npc.getName());
+        heading.setFont(heading.getFont().deriveFont(Font.BOLD, 18f));
+        heading.setAlignmentX(Component.CENTER_ALIGNMENT);
+        panel.add(heading);
+
+        label(panel, "Age: " + npc.getAge() + " turns");
+        double hpMax = game.npcMaxHp(npc);
+        iconLabel(panel, "/assets/icons/health.png",
+                String.format("%.1f/%.1f", npc.getHp(), hpMax));
+        iconLabel(panel, "/assets/icons/energy.png",
+                String.format("%.0f%%", npc.getEnergy()));
+
+        String abil = String.join(", ", npc.getAbilities());
+        label(panel, "Abilities: " + (abil.isEmpty() ? "None" : abil));
+
+        if (!npc.getHunts().isEmpty()) {
+            label(panel, "Successful Hunts:");
+            npc.getHunts().entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(e -> label(panel, "  " + e.getKey() + ": " + e.getValue()));
+        } else {
+            label(panel, "Successful Hunts: None");
+        }
+
+        label(panel, "Egg clusters eaten: " + npc.getEggClustersEaten());
+        iconLabel(panel, "/assets/icons/weight.png",
+                String.format("%.1f", npc.getWeight()));
+        iconLabel(panel, "/assets/icons/attack.png",
+                String.format("%.1f", game.npcEffectiveAttack(npc)));
+        iconLabel(panel, "/assets/icons/speed.png",
+                String.format("%.1f", game.npcEffectiveSpeed(npc)));
+
         JButton close = new JButton("Close");
         close.addActionListener(e -> dispose());
-        add(close, BorderLayout.SOUTH);
+        JPanel btn = new JPanel();
+        btn.add(close);
+        add(btn, BorderLayout.SOUTH);
         pack();
         setLocationRelativeTo(parent);
     }
 
-    private String buildText(Game game, NPCAnimal npc) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Name: ").append(npc.getName()).append('\n');
-        sb.append("Age: ").append(npc.getAge()).append(" turns\n");
-        sb.append(String.format("Weight: %.1f\n", npc.getWeight()));
-        sb.append(String.format("HP: %.1f/%.1f\n", npc.getHp(), game.npcMaxHp(npc)));
-        sb.append(String.format("Energy: %.0f%%\n", npc.getEnergy()));
-        sb.append(String.format("Attack: %.1f\n", game.npcEffectiveAttack(npc)));
-        sb.append(String.format("Speed: %.1f\n", game.npcEffectiveSpeed(npc)));
-        return sb.toString();
+    private static void label(JPanel p, String text) {
+        JLabel l = new JLabel(text);
+        l.setAlignmentX(Component.LEFT_ALIGNMENT);
+        p.add(l);
+    }
+
+    private static void iconLabel(JPanel p, String iconPath, String text) {
+        JLabel l = new JLabel(text);
+        l.setAlignmentX(Component.LEFT_ALIGNMENT);
+        ImageIcon icon = loadScaledIcon(iconPath, 20, 20, false);
+        if (icon != null) {
+            l.setIcon(icon);
+        }
+        p.add(l);
+    }
+
+    private static String imagePath(String name) {
+        return "/assets/dinosaurs/" + name.toLowerCase().replace(" ", "_") + ".png";
+    }
+
+    private static ImageIcon loadScaledIcon(String path, int w, int h, boolean gray) {
+        java.net.URL url = NpcStatsDialog.class.getResource(path);
+        if (url == null) return null;
+        try {
+            BufferedImage img = ImageIO.read(url);
+            if (gray) {
+                java.awt.image.ColorConvertOp op = new java.awt.image.ColorConvertOp(
+                        java.awt.color.ColorSpace.getInstance(java.awt.color.ColorSpace.CS_GRAY), null);
+                img = op.filter(img, null);
+            }
+            double scaleW = (double) w / img.getWidth();
+            double scaleH = (double) h / img.getHeight();
+            double scale = Math.max(scaleW, scaleH);
+            int newW = (int) Math.round(img.getWidth() * scale);
+            int newH = (int) Math.round(img.getHeight() * scale);
+            Image scaled = img.getScaledInstance(newW, newH, Image.SCALE_SMOOTH);
+            BufferedImage resized = new BufferedImage(newW, newH, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D g2 = resized.createGraphics();
+            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+            g2.drawImage(scaled, 0, 0, null);
+            g2.dispose();
+            int x = Math.max(0, (newW - w) / 2);
+            int y = Math.max(0, (newH - h) / 2);
+            BufferedImage cropped = resized.getSubimage(x, y, w, h);
+            return new ImageIcon(cropped);
+        } catch (IOException ex) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement DinoFactsDialog, EncounterHelpDialog, and GameHelpDialog
- enhance NpcStatsDialog with images and icons
- expose formation on `Game` and show new dialogs from GameWindow
- wire Info, Player Stats, Dinosaur Stats and Help buttons
- add encounter help button

## Testing
- `mvn -f java/pom.xml test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b1150919c832e99b382504a19f6c8