### PR TITLE
Refresh UI after every action and disable buttons on game end

### DIFF
--- a/java/src/main/java/com/dinosurvival/ui/GameWindow.java
+++ b/java/src/main/java/com/dinosurvival/ui/GameWindow.java
@@ -363,7 +363,33 @@ public class GameWindow extends JFrame {
     private void doAction(Runnable r, String msg) {
         r.run();
         log(msg);
-        refreshAll();
+        refreshMap();
+        updateBiomeImage();
+        updateDinoImage();
+        updateStatsPanel();
+        updateActionButtons();
+        updatePlantList();
+        updateEncounterList();
+        updateWeatherPanel();
+        updatePopulationList();
+        checkGameEnd();
+    }
+
+    private void disableActionButtons() {
+        northButton.setEnabled(false);
+        southButton.setEnabled(false);
+        eastButton.setEnabled(false);
+        westButton.setEnabled(false);
+        stayButton.setEnabled(false);
+        drinkButton.setEnabled(false);
+        threatenButton.setEnabled(false);
+        layButton.setEnabled(false);
+    }
+
+    private void checkGameEnd() {
+        if (game.getPlayer().getHp() <= 0 || game.hasWon()) {
+            disableActionButtons();
+        }
     }
 
     public void log(String msg) {


### PR DESCRIPTION
## Summary
- refresh UI in Java GameWindow after each game action
- disable action buttons when the player dies or wins

## Testing
- `mvn -e test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b6fe01a50832e816d5312bc9d4555