### PR TITLE
Fix death handling and add species info

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -877,7 +877,6 @@ public class Game {
             }
             if (died) {
                 generateEncounters();
-                applyTurnCosts(false, 1.0);
                 lastAction = "hunt";
                 return;
             }
@@ -1458,6 +1457,16 @@ public class Game {
 
     public DinosaurStats getPlayer() {
         return player;
+    }
+
+    public java.util.List<Integer> getPopulationHistory(String name) {
+        java.util.List<Integer> list = populationHistory.get(name);
+        return list != null ? java.util.Collections.unmodifiableList(list)
+                : java.util.List.of();
+    }
+
+    public java.util.List<Integer> getTurnHistory() {
+        return java.util.Collections.unmodifiableList(turnHistory);
     }
 
     public int getPlayerX() {

--- a/java/src/main/java/com/dinosurvival/ui/GameWindow.java
+++ b/java/src/main/java/com/dinosurvival/ui/GameWindow.java
@@ -690,7 +690,7 @@ public class GameWindow extends JFrame {
             row.add(img, BorderLayout.WEST);
             row.add(new JLabel(name + " " + count + String.format(" (%.1f%%)", pct)), BorderLayout.CENTER);
             JButton infoBtn = new JButton("Info");
-            infoBtn.addActionListener(ev -> new NpcStatsDialog(this, game, sampleNpc(name)).setVisible(true));
+            infoBtn.addActionListener(ev -> new DinoFactsDialog(this, game, name).setVisible(true));
             row.add(infoBtn, BorderLayout.EAST);
             populationList.add(row);
         }


### PR DESCRIPTION
## Summary
- prevent regeneration when the player is killed
- expose population history and turn history
- show species facts from the population tracker
- display population graphs in the facts dialog

## Testing
- `mvn -f java/pom.xml -q -DskipTests package`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b808bd91c832e905f99967ed02f9b