### PR TITLE
Improve Java UI layout and combat logic

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -865,9 +865,10 @@ public class Game {
         double targetAtk = target.isAlive() ? npcEffectiveAttack(target, stats, x, y) : 0.0;
 
         if (target.isAlive()) {
-            double dmg = damageAfterArmor(targetAtk, stats,
-                    StatsLoader.getDinoStats().getOrDefault(player.getName(), new DinosaurStats()));
-            boolean died = applyDamage(dmg, player, StatsLoader.getDinoStats().get(player.getName()));
+            DinosaurStats playerBase = StatsLoader.getDinoStats().get(player.getName());
+            if (playerBase == null) playerBase = new DinosaurStats();
+            double dmg = damageAfterArmor(targetAtk, stats, playerBase);
+            boolean died = applyDamage(dmg, player, playerBase);
             if (dmg > 0 && target.getAbilities().contains("bleed") && player.getHp() > 0) {
                 int bleed = (player.getAbilities().contains("light_armor") || player.getAbilities().contains("heavy_armor")) ? 2 : 5;
                 player.setBleeding(bleed);

--- a/java/src/main/java/com/dinosurvival/ui/DinoFactsDialog.java
+++ b/java/src/main/java/com/dinosurvival/ui/DinoFactsDialog.java
@@ -38,7 +38,7 @@ public class DinoFactsDialog extends JDialog {
         }
         JLabel heading = new JLabel(name);
         heading.setFont(heading.getFont().deriveFont(Font.BOLD, 18f));
-        heading.setAlignmentX(Component.CENTER_ALIGNMENT);
+        heading.setAlignmentX(Component.LEFT_ALIGNMENT);
         panel.add(heading);
 
         Object info = StatsLoader.getDinoStats().get(name);

--- a/java/src/main/java/com/dinosurvival/ui/GameWindow.java
+++ b/java/src/main/java/com/dinosurvival/ui/GameWindow.java
@@ -296,9 +296,11 @@ public class GameWindow extends JFrame {
         encounterPanel.add(encounterScroll, BorderLayout.CENTER);
         c.gridx = 2;
         c.gridy = 1;
+        c.gridheight = 2;
         c.weightx = 1;
         c.weighty = 1;
         main.add(encounterPanel, c);
+        c.gridheight = 1;
 
         // Weather info (row 0, column 3)
         JPanel weatherPanel = new JPanel();
@@ -327,9 +329,11 @@ public class GameWindow extends JFrame {
         popPanel.add(popScroll, BorderLayout.CENTER);
         c.gridx = 3;
         c.gridy = 1;
+        c.gridheight = 2;
         c.weightx = 1;
         c.weighty = 1;
         main.add(popPanel, c);
+        c.gridheight = 1;
 
         // Log area at the bottom spanning two columns
         JScrollPane scroll = new JScrollPane(logArea);
@@ -551,15 +555,17 @@ public class GameWindow extends JFrame {
         }
         for (EncounterEntry e : entries) {
             JPanel row = new JPanel(new BorderLayout());
+            row.setMaximumSize(new Dimension(Integer.MAX_VALUE, 70));
+            row.setPreferredSize(new Dimension(0, 70));
             JLabel img = new JLabel();
+            img.setPreferredSize(new Dimension(100, 70));
             JPanel info = new JPanel();
             info.setLayout(new BoxLayout(info, BoxLayout.Y_AXIS));
             row.add(img, BorderLayout.WEST);
             row.add(info, BorderLayout.CENTER);
             JButton actBtn = new JButton();
             JButton statsBtn = new JButton("Stats");
-            JPanel btns = new JPanel();
-            btns.setLayout(new GridLayout(2,1));
+            JPanel btns = new JPanel(new FlowLayout(FlowLayout.RIGHT, 5, 0));
             btns.add(statsBtn);
             btns.add(actBtn);
             row.add(btns, BorderLayout.EAST);

--- a/java/src/main/java/com/dinosurvival/ui/NpcStatsDialog.java
+++ b/java/src/main/java/com/dinosurvival/ui/NpcStatsDialog.java
@@ -27,7 +27,7 @@ public class NpcStatsDialog extends JDialog {
 
         JLabel heading = new JLabel(npc.getName());
         heading.setFont(heading.getFont().deriveFont(Font.BOLD, 18f));
-        heading.setAlignmentX(Component.CENTER_ALIGNMENT);
+        heading.setAlignmentX(Component.LEFT_ALIGNMENT);
         panel.add(heading);
 
         label(panel, "Age: " + npc.getAge() + " turns");


### PR DESCRIPTION
## Summary
- left-align headings in dino facts and NPC stats dialogs
- stretch encounter and population panes to the bottom of the window
- keep encounter entries compact and arrange buttons horizontally
- use proper player base stats when applying NPC damage

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_686b8635de40832e930470c083ebb688