### PR TITLE
Add threaten action tests

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -1018,8 +1018,10 @@ public class Game {
             if (npcA > playerA) stronger.add(npc); else weaker.add(npc);
         }
         Random r = new Random();
+        boolean killed = false;
         if (!stronger.isEmpty()) {
             player.setHp(0.0);
+            killed = true;
         } else {
             java.util.Map<String,int[]> dirs = java.util.Map.of(
                     "Up", new int[]{0,-1}, "Right", new int[]{1,0},
@@ -1043,6 +1045,9 @@ public class Game {
         generateEncounters();
         aggressiveAttackCheck();
         applyTurnCosts(false, 2.0);
+        if (killed) {
+            player.setHp(0.0);
+        }
         checkVictory();
         lastAction = "threaten";
     }

--- a/java/src/test/java/com/dinosurvival/ThreatenTest.java
+++ b/java/src/test/java/com/dinosurvival/ThreatenTest.java
@@ -1,0 +1,68 @@
+package com.dinosurvival;
+
+import com.dinosurvival.game.Game;
+import com.dinosurvival.game.Map;
+import com.dinosurvival.model.NPCAnimal;
+import com.dinosurvival.util.StatsLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ThreatenTest {
+    @BeforeAll
+    public static void loadStats() throws Exception {
+        Path base = Path.of("..", "dinosurvival");
+        if (Files.exists(base)) {
+            StatsLoader.load(base, "Morrison");
+        }
+    }
+
+    @Test
+    public void testThreatenScatter() {
+        Game g = new Game();
+        g.start("Morrison", "Allosaurus");
+        Map map = g.getMap();
+        int x = g.getPlayerX();
+        int y = g.getPlayerY();
+        map.getAnimals(x, y).clear();
+        NPCAnimal npc1 = new NPCAnimal();
+        npc1.setId(1);
+        npc1.setName("Stegosaurus");
+        npc1.setWeight(1.0);
+        npc1.setLastAction("spawned");
+        NPCAnimal npc2 = new NPCAnimal();
+        npc2.setId(2);
+        npc2.setName("Stegosaurus");
+        npc2.setWeight(1.0);
+        npc2.setLastAction("spawned");
+        map.addAnimal(x, y, npc1);
+        map.addAnimal(x, y, npc2);
+        double base = g.getPlayer().getHatchlingEnergyDrain();
+        g.getPlayer().setEnergy(100.0);
+        g.threaten();
+        double expected = 100.0 - base * 2 * g.getWeather().getPlayerEnergyMult();
+        Assertions.assertEquals(expected, g.getPlayer().getEnergy(), 0.0001);
+        Assertions.assertNotEquals("None", npc1.getNextMove());
+        Assertions.assertNotEquals("None", npc2.getNextMove());
+    }
+
+    @Test
+    public void testThreatenKilledByStronger() {
+        Game g = new Game();
+        g.start("Morrison", "Allosaurus");
+        Map map = g.getMap();
+        int x = g.getPlayerX();
+        int y = g.getPlayerY();
+        map.getAnimals(x, y).clear();
+        NPCAnimal strong = new NPCAnimal();
+        strong.setId(1);
+        strong.setName("Allosaurus");
+        strong.setWeight(3000.0);
+        strong.setLastAction("spawned");
+        map.addAnimal(x, y, strong);
+        g.threaten();
+        Assertions.assertEquals(0.0, g.getPlayer().getHp(), 0.0001);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ThreatenTest` mirroring Python tests
- fix `Game.threaten` so HP stays at 0 when killed

## Testing
- `mvn -f java/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_686b8bdc64a8832eb9e844ed67469404