### PR TITLE
Add bleed and bone break tests

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -405,7 +405,7 @@ public class Game {
         });
     }
 
-    private void updateNpcs() {
+    void updateNpcs() {
         Random r = new Random();
         for (int ty = 0; ty < map.getHeight(); ty++) {
             for (int tx = 0; tx < map.getWidth(); tx++) {
@@ -745,7 +745,7 @@ public class Game {
         }
     }
 
-    private void applyTurnCosts(boolean moved, double multiplier) {
+    void applyTurnCosts(boolean moved, double multiplier) {
         double drain = player.getHatchlingEnergyDrain();
         if (moved) {
             drain *= player.getWalkingEnergyDrainMultiplier();
@@ -1066,6 +1066,7 @@ public class Game {
                 case "adult_speed" -> ds.getAdultSpeed();
                 case "attack" -> ds.getAttack();
                 case "hatchling_weight" -> ds.getHatchlingWeight();
+                case "hp" -> ds.getAdultHp();
                 default -> 0.0;
             };
         } else if (stats instanceof java.util.Map<?,?> map) {

--- a/java/src/test/java/com/dinosurvival/game/BleedTest.java
+++ b/java/src/test/java/com/dinosurvival/game/BleedTest.java
@@ -1,0 +1,69 @@
+package com.dinosurvival.game;
+
+import com.dinosurvival.game.Game;
+import com.dinosurvival.game.Map;
+import com.dinosurvival.model.NPCAnimal;
+import com.dinosurvival.util.StatsLoader;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BleedTest {
+    @Test
+    public void testPlayerBleedsTarget() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
+        Game g = new Game();
+        g.start("Hell Creek", "Acheroraptor");
+        Map map = g.getMap();
+        int x = g.getPlayerX();
+        int y = g.getPlayerY();
+        for (int ty = 0; ty < map.getHeight(); ty++) {
+            for (int tx = 0; tx < map.getWidth(); tx++) {
+                map.getAnimals(tx, ty).clear();
+            }
+        }
+        NPCAnimal target = new NPCAnimal();
+        target.setId(1);
+        target.setName("Acheroraptor");
+        target.setWeight(100.0);
+        target.setLastAction("spawned");
+        map.addAnimal(x, y, target);
+        g.getPlayer().setWeight(g.getPlayer().getAdultWeight());
+        g.getPlayer().setAttack(1.0);
+        g.getPlayer().setHp(g.getPlayer().getAdultHp());
+        g.getPlayer().setSpeed(1000.0);
+        g.huntNpc(target.getId());
+        g.updateNpcs();
+        Assertions.assertEquals(4, target.getBleeding());
+    }
+
+    @Test
+    public void testNpcBleedsPlayer() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Morrison");
+        Game g = new Game();
+        g.start("Morrison", "Ceratosaurus");
+        Map map = g.getMap();
+        int x = g.getPlayerX();
+        int y = g.getPlayerY();
+        for (int ty = 0; ty < map.getHeight(); ty++) {
+            for (int tx = 0; tx < map.getWidth(); tx++) {
+                map.getAnimals(tx, ty).clear();
+            }
+        }
+        NPCAnimal npc = new NPCAnimal();
+        npc.setId(1);
+        npc.setName("Allosaurus");
+        npc.setWeight(100.0);
+        npc.setAbilities(List.of("bleed"));
+        npc.setLastAction("spawned");
+        map.addAnimal(x, y, npc);
+        g.getPlayer().setWeight(g.getPlayer().getAdultWeight());
+        g.getPlayer().setAttack(g.getPlayer().getAdultAttack() * (g.getPlayer().getWeight() / g.getPlayer().getAdultWeight()));
+        g.getPlayer().setHp(g.getPlayer().getAdultHp());
+        g.getPlayer().setSpeed(1000.0);
+        g.huntNpc(npc.getId());
+        g.updateNpcs();
+        Assertions.assertEquals(4, g.getPlayer().getBleeding());
+    }
+}

--- a/java/src/test/java/com/dinosurvival/game/BoneBreakTest.java
+++ b/java/src/test/java/com/dinosurvival/game/BoneBreakTest.java
@@ -1,0 +1,80 @@
+package com.dinosurvival.game;
+
+import com.dinosurvival.game.Game;
+import com.dinosurvival.game.Map;
+import com.dinosurvival.model.NPCAnimal;
+import com.dinosurvival.util.StatsLoader;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BoneBreakTest {
+    @Test
+    public void testPlayerBreaksBonesTarget() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
+        Game g = new Game();
+        g.start("Hell Creek", "Acheroraptor");
+        Map map = g.getMap();
+        int x = g.getPlayerX();
+        int y = g.getPlayerY();
+        for (int ty = 0; ty < map.getHeight(); ty++) {
+            for (int tx = 0; tx < map.getWidth(); tx++) {
+                map.getAnimals(tx, ty).clear();
+            }
+        }
+        NPCAnimal target = new NPCAnimal();
+        target.setId(1);
+        target.setName("Acheroraptor");
+        target.setWeight(40.0);
+        target.setLastAction("spawned");
+        map.addAnimal(x, y, target);
+        g.getPlayer().getAbilities().add("bone_break");
+        g.getPlayer().setWeight(60.0);
+        g.getPlayer().setAttack(1.0);
+        g.getPlayer().setHp(g.getPlayer().getAdultHp());
+        g.getPlayer().setSpeed(1000.0);
+        g.huntNpc(target.getId());
+        g.updateNpcs();
+        Assertions.assertEquals(9, target.getBrokenBone());
+    }
+
+    @Test
+    public void testNpcBreaksPlayerBones() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
+        Game g = new Game();
+        g.start("Hell Creek", "Acheroraptor");
+        Map map = g.getMap();
+        int x = g.getPlayerX();
+        int y = g.getPlayerY();
+        for (int ty = 0; ty < map.getHeight(); ty++) {
+            for (int tx = 0; tx < map.getWidth(); tx++) {
+                map.getAnimals(tx, ty).clear();
+            }
+        }
+        NPCAnimal npc = new NPCAnimal();
+        npc.setId(1);
+        npc.setName("Acheroraptor");
+        npc.setWeight(60.0);
+        npc.setAbilities(List.of("bone_break"));
+        npc.setLastAction("spawned");
+        map.addAnimal(x, y, npc);
+        g.getPlayer().setWeight(40.0);
+        g.getPlayer().setAttack(1.0);
+        g.getPlayer().setHp(g.getPlayer().getAdultHp());
+        g.getPlayer().setSpeed(1000.0);
+        g.huntNpc(npc.getId());
+        g.updateNpcs();
+        Assertions.assertEquals(9, g.getPlayer().getBrokenBone());
+    }
+
+    @Test
+    public void testBrokenBoneHalvesSpeed() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
+        Game g = new Game();
+        g.start("Hell Creek", "Acheroraptor");
+        g.getPlayer().setSpeed(10.0);
+        g.getPlayer().setBrokenBone(5);
+        Assertions.assertEquals(5.0, g.playerEffectiveSpeed(), 1e-9);
+    }
+}


### PR DESCRIPTION
## Summary
- expose helpers in `Game` for tests
- ensure `getStat` returns HP for dinosaur stats
- test bleed interactions in `BleedTest`
- test bone-break ability in `BoneBreakTest`

## Testing
- `mvn -f java/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_686b8e34d6f8832e8055c1600f3673cd