### PR TITLE
Add bleed damage tests

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -762,6 +762,10 @@ public class Game {
         applyBleedAndRegen(player, player.getHealthRegen(), moved, !player.isExhausted());
     }
 
+    void applyTurnCosts(boolean moved) {
+        applyTurnCosts(moved, 1.0);
+    }
+
     private void startTurn() {
         turn++;
         recordPopulation();

--- a/java/src/test/java/com/dinosurvival/game/BleedDamageTest.java
+++ b/java/src/test/java/com/dinosurvival/game/BleedDamageTest.java
@@ -1,0 +1,67 @@
+package com.dinosurvival.game;
+
+import com.dinosurvival.model.DinosaurStats;
+import com.dinosurvival.model.NPCAnimal;
+import com.dinosurvival.util.StatsLoader;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BleedDamageTest {
+
+    @Test
+    public void testBleedDamageAndExpires() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
+        Game game = new Game();
+        game.start("Hell Creek", "Acheroraptor");
+        Map map = game.getMap();
+        for (int ty = 0; ty < map.getHeight(); ty++) {
+            for (int tx = 0; tx < map.getWidth(); tx++) {
+                map.getAnimals(tx, ty).clear();
+            }
+        }
+        DinosaurStats stats = StatsLoader.getDinoStats().get("Acheroraptor");
+        double weight = stats.getAdultWeight();
+        double pct = stats.getAdultWeight() > 0 ? weight / stats.getAdultWeight() : 1.0;
+        pct = Math.max(0.0, Math.min(1.0, pct));
+        double maxHp = stats.getAdultHp() * pct;
+        NPCAnimal target = new NPCAnimal();
+        target.setId(1);
+        target.setName("Acheroraptor");
+        target.setWeight(weight);
+        target.setMaxHp(maxHp);
+        target.setHp(maxHp);
+        map.addAnimal(game.getPlayerX(), game.getPlayerY(), target);
+
+        target.setBleeding(5);
+        double hpBefore = target.getHp();
+        for (int i = 0; i < 5; i++) {
+            game.updateNpcs();
+        }
+        Assertions.assertTrue(target.getHp() < hpBefore);
+        Assertions.assertEquals(0, target.getBleeding());
+    }
+
+    @Test
+    public void testPlayerMovingWhileBleedingTakesExtraDamage() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
+        Game game = new Game();
+        game.start("Hell Creek", "Acheroraptor");
+        DinosaurStats player = game.getPlayer();
+        player.setWeight(player.getAdultWeight());
+        player.setMaxHp(player.getAdultHp());
+        player.setHp(player.getMaxHp());
+        player.setBleeding(1);
+
+        double hpBeforeMove = player.getHp();
+        game.applyTurnCosts(true);
+        double moveLoss = hpBeforeMove - player.getHp();
+
+        player.setHp(hpBeforeMove);
+        player.setBleeding(1);
+        game.applyTurnCosts(false);
+        double stayLoss = hpBeforeMove - player.getHp();
+
+        Assertions.assertEquals(moveLoss, stayLoss * 2, 1e-9);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for bleeding damage and movement hp loss
- expose simplified applyTurnCosts for tests

## Testing
- `mvn -f java/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_686b93b69104832e96975b3cefb7bbd3