### PR TITLE
Add volcano tests and deterministic map

### DIFF
--- a/java/src/test/java/com/dinosurvival/game/VolcanoGenerationTest.java
+++ b/java/src/test/java/com/dinosurvival/game/VolcanoGenerationTest.java
@@ -1,0 +1,26 @@
+package com.dinosurvival.game;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class VolcanoGenerationTest {
+    @Test
+    public void testVolcanoGenerationRate() {
+        Map map = new Map(40, 40, 0L);
+        int volcano = 0;
+        int mountain = 0;
+        for (int y = 0; y < map.getHeight(); y++) {
+            for (int x = 0; x < map.getWidth(); x++) {
+                Terrain t = map.terrainAt(x, y);
+                if (t == Terrain.VOLCANO) {
+                    volcano++;
+                } else if (t == Terrain.MOUNTAIN) {
+                    mountain++;
+                }
+            }
+        }
+        double ratio = volcano / (double) (volcano + mountain);
+        Assertions.assertTrue(ratio >= 0.4 && ratio <= 0.6,
+                "Volcano to mountain ratio out of expected range: " + ratio);
+    }
+}

--- a/java/src/test/java/com/dinosurvival/game/VolcanoPersistenceTest.java
+++ b/java/src/test/java/com/dinosurvival/game/VolcanoPersistenceTest.java
@@ -1,0 +1,40 @@
+package com.dinosurvival.game;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class VolcanoPersistenceTest {
+    @Test
+    public void testVolcanoTileRemainsAfterEruption() throws Exception {
+        Map map = new Map(6, 6, 0L);
+
+        Field gridField = Map.class.getDeclaredField("grid");
+        gridField.setAccessible(true);
+        Field lavaInfoField = Map.class.getDeclaredField("lavaInfo");
+        lavaInfoField.setAccessible(true);
+        Field eruptField = Map.class.getDeclaredField("erupting");
+        eruptField.setAccessible(true);
+
+        Terrain[][] grid = (Terrain[][]) gridField.get(map);
+        LavaInfo[][] lavaInfo = (LavaInfo[][]) lavaInfoField.get(map);
+        boolean[][] erupting = (boolean[][]) eruptField.get(map);
+        for (int y = 0; y < map.getHeight(); y++) {
+            for (int x = 0; x < map.getWidth(); x++) {
+                grid[y][x] = Terrain.PLAINS;
+                lavaInfo[y][x] = null;
+                erupting[y][x] = false;
+            }
+        }
+        grid[3][3] = Terrain.VOLCANO;
+
+        map.startVolcanoEruption(3, 3, "medium");
+        Assertions.assertEquals(Terrain.VOLCANO_ERUPTING, map.terrainAt(3, 3));
+
+        for (int i = 0; i < 3; i++) {
+            map.updateVolcanicActivity();
+        }
+
+        Assertions.assertEquals(Terrain.VOLCANO, map.terrainAt(3, 3));
+    }
+}


### PR DESCRIPTION
## Summary
- support deterministic map generation via seed
- ensure volcano ratio is within expected range
- verify volcano tiles revert to volcano after eruption

## Testing
- `mvn -f java/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_686b96e6b41c832eb1fee21de2a3ae0b