### PR TITLE
Add hunt tracking and critter spawn tests

### DIFF
--- a/java/src/test/java/com/dinosurvival/game/HuntsTest.java
+++ b/java/src/test/java/com/dinosurvival/game/HuntsTest.java
@@ -1,0 +1,98 @@
+package com.dinosurvival.game;
+
+import com.dinosurvival.model.NPCAnimal;
+import com.dinosurvival.util.StatsLoader;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class HuntsTest {
+
+    @Test
+    public void testLiveHuntCountsKill() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Morrison");
+        Game game = new Game();
+        game.start("Morrison", "Allosaurus");
+        Map map = game.getMap();
+        for (int ty = 0; ty < map.getHeight(); ty++) {
+            for (int tx = 0; tx < map.getWidth(); tx++) {
+                map.getAnimals(tx, ty).clear();
+            }
+        }
+        NPCAnimal npc = new NPCAnimal();
+        npc.setId(1);
+        npc.setName("Stegosaurus");
+        npc.setWeight(1.0);
+        map.addAnimal(game.getPlayerX(), game.getPlayerY(), npc);
+        game.huntNpc(npc.getId());
+        Assertions.assertEquals(1, game.getHuntStats().get("Stegosaurus")[1]);
+    }
+
+    @Test
+    public void testCarcassEatNotCountedAsHunt() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Morrison");
+        Game game = new Game();
+        game.start("Morrison", "Allosaurus");
+        Map map = game.getMap();
+        for (int ty = 0; ty < map.getHeight(); ty++) {
+            for (int tx = 0; tx < map.getWidth(); tx++) {
+                map.getAnimals(tx, ty).clear();
+            }
+        }
+        NPCAnimal carcass = new NPCAnimal();
+        carcass.setId(1);
+        carcass.setName("Stegosaurus");
+        carcass.setAlive(false);
+        carcass.setWeight(1.0);
+        map.addAnimal(game.getPlayerX(), game.getPlayerY(), carcass);
+        game.huntNpc(carcass.getId());
+        Assertions.assertFalse(game.getHuntStats().containsKey("Stegosaurus"));
+    }
+
+    @Test
+    public void testPlayerTakesDamageWhenHuntingCritter() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
+        Game game = new Game();
+        game.start("Hell Creek", "Tyrannosaurus");
+        Map map = game.getMap();
+        for (int ty = 0; ty < map.getHeight(); ty++) {
+            for (int tx = 0; tx < map.getWidth(); tx++) {
+                map.getAnimals(tx, ty).clear();
+            }
+        }
+        game.getPlayer().setHealthRegen(0.0);
+        NPCAnimal critter = new NPCAnimal();
+        critter.setId(1);
+        critter.setName("Didelphodon");
+        critter.setWeight(5.0);
+        map.addAnimal(game.getPlayerX(), game.getPlayerY(), critter);
+        game.huntNpc(critter.getId());
+        Assertions.assertTrue(game.getPlayer().getHp() < game.getPlayer().getMaxHp());
+    }
+
+    @Test
+    public void testNpcTakesDamageWhenHuntingCritter() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
+        Game game = new Game();
+        game.start("Hell Creek", "Tyrannosaurus");
+        Map map = game.getMap();
+        for (int ty = 0; ty < map.getHeight(); ty++) {
+            for (int tx = 0; tx < map.getWidth(); tx++) {
+                map.getAnimals(tx, ty).clear();
+            }
+        }
+        NPCAnimal predator = new NPCAnimal();
+        predator.setId(1);
+        predator.setName("Acheroraptor");
+        predator.setWeight(10.0);
+        predator.setEnergy(50.0);
+        NPCAnimal prey = new NPCAnimal();
+        prey.setId(2);
+        prey.setName("Didelphodon");
+        prey.setWeight(5.0);
+        map.addAnimal(0, 0, predator);
+        map.addAnimal(0, 0, prey);
+        game.updateNpcs();
+        Assertions.assertTrue(predator.getHp() < predator.getMaxHp());
+    }
+}

--- a/java/src/test/java/com/dinosurvival/game/InitialCritterSpawnTest.java
+++ b/java/src/test/java/com/dinosurvival/game/InitialCritterSpawnTest.java
@@ -1,0 +1,54 @@
+package com.dinosurvival.game;
+
+import com.dinosurvival.util.StatsLoader;
+import com.dinosurvival.model.NPCAnimal;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class InitialCritterSpawnTest {
+
+    @Test
+    public void testInitialCritterSpawnAndPlacement() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Morrison");
+        Game game = new Game();
+        game.start("Morrison", "Allosaurus");
+        java.util.Map<String, java.util.Map<String, Object>> critters = StatsLoader.getCritterStats();
+        com.dinosurvival.game.Map map = game.getMap();
+        for (java.util.Map.Entry<String, java.util.Map<String, Object>> entry : critters.entrySet()) {
+            String name = entry.getKey();
+            java.util.Map<String, Object> stats = entry.getValue();
+            int count = 0;
+            for (int y = 0; y < map.getHeight(); y++) {
+                for (int x = 0; x < map.getWidth(); x++) {
+                    List<NPCAnimal> cell = map.getAnimals(x, y);
+                    int perTile = 0;
+                    for (NPCAnimal npc : cell) {
+                        if (name.equals(npc.getName())) {
+                            perTile++;
+                        }
+                    }
+                    if (perTile > 0) {
+                        Terrain t = map.terrainAt(x, y);
+                        boolean canWalk = !Boolean.FALSE.equals(stats.get("can_walk"));
+                        if (canWalk) {
+                            Assertions.assertNotEquals(Terrain.LAKE, t);
+                        } else {
+                            Assertions.assertEquals(Terrain.LAKE, t);
+                        }
+                        Assertions.assertEquals(1, perTile);
+                        count += perTile;
+                    }
+                }
+            }
+            int maxInd = 0;
+            Object val = stats.get("maximum_individuals");
+            if (val instanceof Number n) {
+                maxInd = n.intValue();
+            }
+            Assertions.assertTrue(count <= maxInd / 2);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track hunts via new `huntStats` map in `Game`
- update NPC logic to perform simple hunts
- add `HuntsTest` for hunt behaviour
- add `InitialCritterSpawnTest` covering critter spawns

## Testing
- `mvn -f java/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_686b970d2b94832e96ccb6539b207ce8