### PR TITLE
Add forest fire lifecycle

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Map.java
+++ b/java/src/main/java/com/dinosurvival/game/Map.java
@@ -531,6 +531,31 @@ public class Map {
         return msgs;
     }
 
+    /**
+     * Ignite a forest fire at the specified location.
+     *
+     * <p>This mirrors the Python helper used by the tests and resets the
+     * associated counters so {@link #updateForestFire()} can progress the
+     * burning and eventual regrowth.</p>
+     */
+    public void startForestFire(int x, int y) {
+        Terrain t = terrainAt(x, y);
+        if (t == Terrain.FOREST) {
+            grid[y][x] = Terrain.FOREST_FIRE;
+        } else if (t == Terrain.HIGHLAND_FOREST) {
+            grid[y][x] = Terrain.HIGHLAND_FOREST_FIRE;
+        } else {
+            return;
+        }
+
+        fireTurns[y][x] = 5;
+        burntTurns[y][x] = 0;
+        animals[y][x].clear();
+        eggs[y][x].clear();
+        burrows[y][x] = null;
+        plants[y][x].clear();
+    }
+
     public List<String> updateForestFire() {
         List<String> msgs = new ArrayList<>();
         for (int y = 0; y < height; y++) {

--- a/java/src/test/java/com/dinosurvival/game/ForestFireTest.java
+++ b/java/src/test/java/com/dinosurvival/game/ForestFireTest.java
@@ -1,0 +1,57 @@
+package com.dinosurvival.game;
+
+import com.dinosurvival.model.NPCAnimal;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+public class ForestFireTest {
+
+    private static Map prepareForestMap() throws Exception {
+        Map map = new Map(5, 5, 0L);
+        Field gridF = Map.class.getDeclaredField("grid");
+        Field fireF = Map.class.getDeclaredField("fireTurns");
+        Field burntF = Map.class.getDeclaredField("burntTurns");
+        gridF.setAccessible(true);
+        fireF.setAccessible(true);
+        burntF.setAccessible(true);
+        Terrain[][] grid = (Terrain[][]) gridF.get(map);
+        int[][] fire = (int[][]) fireF.get(map);
+        int[][] burnt = (int[][]) burntF.get(map);
+        for (int y = 0; y < map.getHeight(); y++) {
+            for (int x = 0; x < map.getWidth(); x++) {
+                grid[y][x] = Terrain.FOREST;
+                fire[y][x] = 0;
+                burnt[y][x] = 0;
+            }
+        }
+        return map;
+    }
+
+    @Test
+    public void testForestFireRevertsToOriginalTile() throws Exception {
+        Map map = prepareForestMap();
+        int x = 2;
+        int y = 2;
+        NPCAnimal npc = new NPCAnimal();
+        npc.setId(1);
+        npc.setName("Test");
+        npc.setWeight(10.0);
+        map.addAnimal(x, y, npc);
+
+        map.startForestFire(x, y);
+        Assertions.assertEquals(Terrain.FOREST_FIRE, map.terrainAt(x, y));
+        Assertions.assertTrue(map.getAnimals(x, y).isEmpty());
+
+        for (int i = 0; i < 5; i++) {
+            map.updateForestFire();
+        }
+        Assertions.assertEquals(Terrain.FOREST_BURNT, map.terrainAt(x, y));
+
+        for (int i = 0; i < 50; i++) {
+            map.updateForestFire();
+        }
+        Assertions.assertEquals(Terrain.FOREST, map.terrainAt(x, y));
+    }
+}


### PR DESCRIPTION
## Summary
- support triggering forest fires and handle burn/revert
- test forest fire lifecycle matches Python tests

## Testing
- `mvn -f java/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_686b9cfe5b1c832e92275918cde29fd8