### PR TITLE
Add combat logging to Java Game

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -37,6 +37,7 @@ public class Game {
     private final java.util.Map<String, List<Integer>> populationHistory = new java.util.HashMap<>();
     private final java.util.Map<String, int[]> huntStats = new java.util.HashMap<>();
     private final List<Integer> turnHistory = new ArrayList<>();
+    private List<String> turnMessages = new ArrayList<>();
     private String formation;
 
     /** Number of descendants required to win the game. */
@@ -96,6 +97,8 @@ public class Game {
             populationHistory.putIfAbsent(name, new ArrayList<>());
         }
         recordPopulation();
+        turn = 0;
+        turnMessages.clear();
     }
 
     private DinosaurStats cloneStats(DinosaurStats src) {
@@ -818,11 +821,13 @@ public class Game {
     }
 
     private void startTurn() {
+        turnMessages.clear();
         turn++;
         recordPopulation();
         if (weatherTurns >= 10) {
             weather = chooseWeather();
             weatherTurns = 0;
+            turnMessages.add("The weather changes to " + weather.getName() + ".");
         }
         weatherTurns++;
 
@@ -931,7 +936,14 @@ public class Game {
             DinosaurStats playerBase = StatsLoader.getDinoStats().get(player.getName());
             if (playerBase == null) playerBase = new DinosaurStats();
             double dmg = damageAfterArmor(targetAtk, stats, playerBase);
+            double beforePlayer = player.getHp();
             boolean died = applyDamage(dmg, player, playerBase);
+            double playerDamage = beforePlayer - player.getHp();
+            if (playerDamage > 0) {
+                turnMessages.add("The " + npcLabel(target) + " deals " +
+                        String.format(java.util.Locale.US, "%.0f", playerDamage) +
+                        " damage to you.");
+            }
             if (dmg > 0 && target.getAbilities().contains("bleed") && player.getHp() > 0) {
                 int bleed = (player.getAbilities().contains("light_armor") || player.getAbilities().contains("heavy_armor")) ? 2 : 5;
                 player.setBleeding(bleed);
@@ -948,7 +960,14 @@ public class Game {
 
         double dmgToTarget = damageAfterArmor(playerAtk,
                 StatsLoader.getDinoStats().get(player.getName()), stats);
+        double beforeTarget = target.getHp();
         boolean targetDied = applyDamage(dmgToTarget, target, stats);
+        double dealt = beforeTarget - target.getHp();
+        if (dealt > 0) {
+            turnMessages.add("You deal " +
+                    String.format(java.util.Locale.US, "%.0f", dealt) +
+                    " damage to the " + npcLabel(target) + ".");
+        }
         if (dmgToTarget > 0 && player.getAbilities().contains("bleed") && target.getHp() > 0 && target.isAlive()) {
             int bleed = (target.getAbilities().contains("light_armor") || target.getAbilities().contains("heavy_armor")) ? 2 : 5;
             target.setBleeding(bleed);
@@ -1596,6 +1615,10 @@ public class Game {
 
     public java.util.List<Integer> getTurnHistory() {
         return java.util.Collections.unmodifiableList(turnHistory);
+    }
+
+    public java.util.List<String> getTurnMessages() {
+        return java.util.Collections.unmodifiableList(turnMessages);
     }
 
     public java.util.Map<String, int[]> getHuntStats() {

--- a/java/src/test/java/com/dinosurvival/game/DamageMessageTest.java
+++ b/java/src/test/java/com/dinosurvival/game/DamageMessageTest.java
@@ -1,0 +1,42 @@
+package com.dinosurvival.game;
+
+import com.dinosurvival.model.NPCAnimal;
+import com.dinosurvival.util.StatsLoader;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DamageMessageTest {
+    @Test
+    public void testHuntOnlyOneDamageMessage() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
+        Game game = new Game();
+        game.start("Hell Creek", "Tyrannosaurus");
+        Map map = game.getMap();
+        for (int y = 0; y < map.getHeight(); y++) {
+            for (int x = 0; x < map.getWidth(); x++) {
+                map.getAnimals(x, y).clear();
+            }
+        }
+        java.util.Map<String, Object> stats = StatsLoader.getCritterStats().get("Didelphodon");
+        double weight = 0.0;
+        Object w = stats.get("adult_weight");
+        if (w instanceof Number num) weight = num.doubleValue();
+        double hp = 0.0;
+        Object h = stats.get("hp");
+        if (h instanceof Number num) hp = num.doubleValue();
+        NPCAnimal npc = new NPCAnimal();
+        npc.setId(1);
+        npc.setName("Didelphodon");
+        npc.setWeight(weight);
+        npc.setMaxHp(hp);
+        npc.setHp(hp);
+        map.addAnimal(game.getPlayerX(), game.getPlayerY(), npc);
+
+        game.huntNpc(npc.getId());
+        long count = game.getTurnMessages().stream()
+                .filter(m -> m.startsWith("You deal"))
+                .count();
+        Assertions.assertEquals(1, count);
+    }
+}


### PR DESCRIPTION
## Summary
- track per-turn messages in the Java `Game`
- log damage dealt and taken when hunting
- expose `getTurnMessages`
- store weather change messages
- add `DamageMessageTest` covering damage log behaviour

## Testing
- `mvn -f java/pom.xml test` *(fails: There are test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686b9cfd0618832e9f22a0dcce1dd5bb