### PR TITLE
Add Java egg consumption test

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -1013,7 +1013,7 @@ public class Game {
             lastAction = "eggs";
             return;
         }
-        EggCluster egg = eggs.remove(0);
+        EggCluster egg = map.takeEggs(x, y);
         double weight = egg.getWeight();
         double energyGain = 1000 * weight / Math.max(player.getWeight(), 0.1);
         double need = 100.0 - player.getEnergy();
@@ -1278,6 +1278,9 @@ public class Game {
         double remaining = eatAmount - used;
         npcApplyGrowth(npc, remaining, stats);
         egg.setWeight(egg.getWeight() - eatAmount);
+        if (eatAmount > 0) {
+            npc.setEggClustersEaten(npc.getEggClustersEaten() + 1);
+        }
     }
 
     private boolean npcDigBurrow(int x, int y) {

--- a/java/src/test/java/com/dinosurvival/game/EggConsumptionTest.java
+++ b/java/src/test/java/com/dinosurvival/game/EggConsumptionTest.java
@@ -1,0 +1,52 @@
+package com.dinosurvival.game;
+
+import com.dinosurvival.util.StatsLoader;
+import com.dinosurvival.model.NPCAnimal;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class EggConsumptionTest {
+    @Test
+    public void testNpcEggClusterRemovedAfterEating() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Morrison");
+        Game g = new Game();
+        g.start("Morrison", "Allosaurus");
+        Map map = g.getMap();
+        for (int y = 0; y < map.getHeight(); y++) {
+            for (int x = 0; x < map.getWidth(); x++) {
+                map.getAnimals(x, y).clear();
+                map.getEggs(x, y).clear();
+            }
+        }
+        NPCAnimal npc = new NPCAnimal();
+        npc.setId(1);
+        npc.setName("Ceratosaurus");
+        npc.setEnergy(50.0);
+        npc.setWeight(10.0);
+        map.addAnimal(0, 0, npc);
+        map.addEggs(0, 0, new EggCluster("Stegosaurus", 1, 1.0, 5));
+        g.updateNpcs();
+        Assertions.assertTrue(map.getEggs(0, 0).isEmpty());
+        Assertions.assertEquals(1, npc.getEggClustersEaten());
+    }
+
+    @Test
+    public void testPlayerCollectsEggsRemovesCluster() throws Exception {
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Morrison");
+        Game g = new Game();
+        g.start("Morrison", "Allosaurus");
+        Map map = g.getMap();
+        for (int y = 0; y < map.getHeight(); y++) {
+            for (int x = 0; x < map.getWidth(); x++) {
+                map.getAnimals(x, y).clear();
+                map.getEggs(x, y).clear();
+            }
+        }
+        int px = g.getPlayerX();
+        int py = g.getPlayerY();
+        map.addEggs(px, py, new EggCluster("Stegosaurus", 2, 2.0, 5));
+        g.collectEggs();
+        Assertions.assertTrue(map.getEggs(px, py).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add EggConsumptionTest matching Python version
- ensure collecting eggs removes clusters via Map.takeEggs
- track egg clusters eaten by NPCs

## Testing
- `mvn -f java/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_686ba22ce3ac832eb4c9b7fe6edb83fb