### PR TITLE
Improve Java game logging and UI effects

### DIFF
--- a/java/src/main/java/com/dinosurvival/ui/GameWindow.java
+++ b/java/src/main/java/com/dinosurvival/ui/GameWindow.java
@@ -98,6 +98,11 @@ public class GameWindow extends JFrame {
         }
     }
 
+    private ImageIcon toGrayscale(ImageIcon src) {
+        Image gray = GrayFilter.createDisabledImage(src.getImage());
+        return new ImageIcon(gray);
+    }
+
     private String formatBiomeName(String name) {
         String[] parts = name.split("_");
         StringBuilder sb = new StringBuilder();
@@ -632,7 +637,12 @@ public class GameWindow extends JFrame {
                         npcImages.put(key, icon);
                     }
                 }
-                if (icon != null) img.setIcon(icon);
+                if (icon != null) {
+                    if (!npc.isAlive()) {
+                        icon = toGrayscale(icon);
+                    }
+                    img.setIcon(icon);
+                }
                 info.add(new JLabel(name + " (" + npc.getId() + ")"));
                 info.add(new JLabel(String.format("A: %.1f  HP: %.1f/%.1f", game.npcEffectiveAttack(npc), npc.getHp(), game.npcMaxHp(npc))));
                 info.add(new JLabel(String.format("S: %.1f  W: %.1fkg", game.npcEffectiveSpeed(npc), npc.getWeight())));

--- a/java/src/test/java/com/dinosurvival/game/DamageMessageTest.java
+++ b/java/src/test/java/com/dinosurvival/game/DamageMessageTest.java
@@ -34,8 +34,9 @@ public class DamageMessageTest {
         map.addAnimal(game.getPlayerX(), game.getPlayerY(), npc);
 
         game.huntNpc(npc.getId());
+        String prefix = game.getPlayer().getName() + " (0) deals";
         long count = game.getTurnMessages().stream()
-                .filter(m -> m.startsWith("You deal"))
+                .filter(m -> m.startsWith(prefix))
                 .count();
         Assertions.assertEquals(1, count);
     }


### PR DESCRIPTION
## Summary
- log combat and feeding events with dino genus/id
- gray out images of dead encounters
- initialize player speed directly to hatchling speed
- adapt combat damage tests for new message format

## Testing
- `mvn -q test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bad4bf88c832eae82842a686a702b