### PR TITLE
Fix HuntsTest flakiness with deterministic map

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -50,7 +50,7 @@ public class Game {
      * world without depending on the Python code.
      */
     public void start() {
-        start("Morrison", null);
+        start("Morrison", null, new Random().nextLong());
     }
 
     /**
@@ -58,6 +58,14 @@ public class Game {
      * If {@code dinoName} is null the first available dinosaur is used.
      */
     public void start(String formation, String dinoName) {
+        start(formation, dinoName, new Random().nextLong());
+    }
+
+    /**
+     * Start a new game using the given formation and player dinosaur name with
+     * the provided random seed for map generation.
+     */
+    public void start(String formation, String dinoName, long seed) {
         try {
             StatsLoader.load(Path.of("dinosurvival"), formation);
             this.formation = formation;
@@ -65,7 +73,7 @@ public class Game {
             throw new RuntimeException(e);
         }
 
-        map = new Map(18, 10);
+        map = new Map(18, 10, seed);
         map.populateBurrows(5);
 
         // choose player dinosaur

--- a/java/src/test/java/com/dinosurvival/game/HuntsTest.java
+++ b/java/src/test/java/com/dinosurvival/game/HuntsTest.java
@@ -12,7 +12,7 @@ public class HuntsTest {
     public void testLiveHuntCountsKill() throws Exception {
         StatsLoader.load(Path.of("..", "dinosurvival"), "Morrison");
         Game game = new Game();
-        game.start("Morrison", "Allosaurus");
+        game.start("Morrison", "Allosaurus", 0L);
         Map map = game.getMap();
         for (int ty = 0; ty < map.getHeight(); ty++) {
             for (int tx = 0; tx < map.getWidth(); tx++) {
@@ -32,7 +32,7 @@ public class HuntsTest {
     public void testCarcassEatNotCountedAsHunt() throws Exception {
         StatsLoader.load(Path.of("..", "dinosurvival"), "Morrison");
         Game game = new Game();
-        game.start("Morrison", "Allosaurus");
+        game.start("Morrison", "Allosaurus", 0L);
         Map map = game.getMap();
         for (int ty = 0; ty < map.getHeight(); ty++) {
             for (int tx = 0; tx < map.getWidth(); tx++) {
@@ -53,7 +53,7 @@ public class HuntsTest {
     public void testPlayerTakesDamageWhenHuntingCritter() throws Exception {
         StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
         Game game = new Game();
-        game.start("Hell Creek", "Tyrannosaurus");
+        game.start("Hell Creek", "Tyrannosaurus", 0L);
         Map map = game.getMap();
         for (int ty = 0; ty < map.getHeight(); ty++) {
             for (int tx = 0; tx < map.getWidth(); tx++) {
@@ -74,7 +74,7 @@ public class HuntsTest {
     public void testNpcTakesDamageWhenHuntingCritter() throws Exception {
         StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
         Game game = new Game();
-        game.start("Hell Creek", "Tyrannosaurus");
+        game.start("Hell Creek", "Tyrannosaurus", 0L);
         Map map = game.getMap();
         for (int ty = 0; ty < map.getHeight(); ty++) {
             for (int tx = 0; tx < map.getWidth(); tx++) {


### PR DESCRIPTION
## Summary
- allow providing a seed when starting a game so the map can be deterministic
- start HuntsTest games with a constant seed

## Testing
- `mvn -f java/pom.xml test -Dtest=HuntsTest`
- `mvn -f java/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_686bb0493614832eaabd74d3b960225e