### PR TITLE
Fix Java game death and hunting mechanics

### DIFF
--- a/java/src/main/java/com/dinosurvival/ui/GameWindow.java
+++ b/java/src/main/java/com/dinosurvival/ui/GameWindow.java
@@ -421,7 +421,8 @@ public class GameWindow extends JFrame {
     }
 
     public void log(String msg) {
-        logArea.append(msg + "\n");
+        logArea.append(game.getTurn() + ": " + msg + "\n");
+        logArea.setCaretPosition(logArea.getDocument().getLength());
     }
 
     private void buildMap() {


### PR DESCRIPTION
## Summary
- add death messages for exhaustion and dehydration in Java version
- prefix log messages with turn count and auto-scroll log
- enforce catch chance and escape logic for player hunts
- require NPC hunters to catch prey based on speed

## Testing
- `mvn -q -f java/pom.xml test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc13d363c832ebb7119aee7e061c8