### PR TITLE
Add bleed waiting logic to NPCs

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -531,6 +531,26 @@ public class Game {
                         }
                     }
 
+                    if (npc.getAbilities().contains("bleed") && npc.getBleedWaitTurns() > 0) {
+                        NPCAnimal target = null;
+                        for (NPCAnimal a : animals) {
+                            if (a.getId() == npc.getBleedWaitTarget()) {
+                                target = a;
+                                break;
+                            }
+                        }
+                        if (target != null && target.isAlive() && target.getBleeding() > 0
+                                && npc.getEnergy() >= 30) {
+                            npc.setBleedWaitTurns(npc.getBleedWaitTurns() - 1);
+                            npc.setNextMove("None");
+                            npc.setLastAction("stay");
+                            continue;
+                        } else {
+                            npc.setBleedWaitTurns(0);
+                            npc.setBleedWaitTarget(-1);
+                        }
+                    }
+
                     if (npc.getEnergy() <= 90) {
                         if (statsDietHas(stats, "meat")) {
                             NPCAnimal carcass = null;


### PR DESCRIPTION
## Summary
- update Java NPC logic to let predators wait for bleeding prey
- decrement broken bones every turn, with halved speed while limping

## Testing
- `pytest -q`
- `mvn -f java/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_686be89eda1c832e8b2a680a7c769a72