### PR TITLE
Fix energy drain handling

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -862,8 +862,14 @@ public class Game {
         }
     }
 
+    /**
+     * Base energy drain depends on the player's current weight.
+     * Hatchling drain is used until the player exceeds half of its
+     * adult weight.
+     */
     private double baseEnergyDrain() {
-        return player.getGrowthStages() > 0
+        double halfAdult = player.getAdultWeight() / 2.0;
+        return player.getWeight() <= halfAdult
                 ? player.getHatchlingEnergyDrain()
                 : player.getAdultEnergyDrain();
     }

--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -862,8 +862,14 @@ public class Game {
         }
     }
 
+    private double baseEnergyDrain() {
+        return player.getGrowthStages() > 0
+                ? player.getHatchlingEnergyDrain()
+                : player.getAdultEnergyDrain();
+    }
+
     void applyTurnCosts(boolean moved, double multiplier) {
-        double drain = player.getHatchlingEnergyDrain();
+        double drain = baseEnergyDrain();
         if (moved) {
             drain *= WALKING_ENERGY_DRAIN_MULTIPLIER;
             if (player.getBrokenBone() > 0) {

--- a/java/src/test/java/com/dinosurvival/ThreatenTest.java
+++ b/java/src/test/java/com/dinosurvival/ThreatenTest.java
@@ -55,7 +55,14 @@ public class ThreatenTest {
         npc2.setLastAction("spawned");
         map.addAnimal(x, y, npc1);
         map.addAnimal(x, y, npc2);
-        double base = g.getPlayer().getHatchlingEnergyDrain();
+        double base;
+        try {
+            java.lang.reflect.Method m = Game.class.getDeclaredMethod("baseEnergyDrain");
+            m.setAccessible(true);
+            base = (double) m.invoke(g);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         g.getPlayer().setEnergy(100.0);
         g.threaten();
         StatsLoader.getCritterStats().putAll(saved);


### PR DESCRIPTION
## Summary
- add `baseEnergyDrain()` to Game
- compute energy drain in `applyTurnCosts` via helper
- update ThreatenTest to use reflection when checking energy drain

## Testing
- `mvn -f java/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_686c02217474832e9cc3ab49bad3c822