### PR TITLE
Use base stats for player egg laying

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -1166,10 +1166,18 @@ public class Game {
             return;
         }
         player.setEnergy(player.getEnergy() * 0.7);
-        double hatchW = player.getHatchlingWeight();
-        EggCluster ec = new EggCluster(player.getName(), 1, hatchW, 5, true);
+        Object stats = StatsLoader.getDinoStats().get(player.getName());
+        int numEggs = (int) getStat(stats, "num_eggs");
+        double hatchW = getStat(stats, "hatchling_weight");
+        if (hatchW <= 0) {
+            double adultW = getStat(stats, "adult_weight");
+            hatchW = Math.max(1.0, adultW * 0.001);
+        }
+        EggCluster ec = new EggCluster(player.getName(), numEggs,
+                hatchW * numEggs, 5, true);
         map.getEggs(x, y).add(ec);
-        player.setTurnsUntilLayEggs(10);
+        int interval = (int) getStat(stats, "egg_laying_interval");
+        player.setTurnsUntilLayEggs(interval);
         generateEncounters();
         aggressiveAttackCheck();
         applyTurnCosts(false, 1.0);
@@ -1259,6 +1267,8 @@ public class Game {
                 case "adult_speed" -> ds.getAdultSpeed();
                 case "attack" -> ds.getAttack();
                 case "hatchling_weight" -> ds.getHatchlingWeight();
+                case "num_eggs" -> ds.getNumEggs();
+                case "egg_laying_interval" -> ds.getEggLayingInterval();
                 case "hp" -> ds.getAdultHp();
                 default -> 0.0;
             };

--- a/java/src/main/java/com/dinosurvival/model/DinosaurStats.java
+++ b/java/src/main/java/com/dinosurvival/model/DinosaurStats.java
@@ -40,6 +40,8 @@ public class DinosaurStats {
     private double aquaticBoost = 0.0;
     private boolean mated = false;
     private int turnsUntilLayEggs = 0;
+    private int numEggs = 0;
+    private int eggLayingInterval = 0;
     private List<Diet> diet = new ArrayList<>();
     private List<String> abilities = new ArrayList<>();
     private List<String> preferredBiomes = new ArrayList<>();
@@ -291,6 +293,22 @@ public class DinosaurStats {
 
     public void setTurnsUntilLayEggs(int turnsUntilLayEggs) {
         this.turnsUntilLayEggs = turnsUntilLayEggs;
+    }
+
+    public int getNumEggs() {
+        return numEggs;
+    }
+
+    public void setNumEggs(int numEggs) {
+        this.numEggs = numEggs;
+    }
+
+    public int getEggLayingInterval() {
+        return eggLayingInterval;
+    }
+
+    public void setEggLayingInterval(int eggLayingInterval) {
+        this.eggLayingInterval = eggLayingInterval;
     }
 
     public List<Diet> getDiet() {

--- a/java/src/test/java/com/dinosurvival/EggsTest.java
+++ b/java/src/test/java/com/dinosurvival/EggsTest.java
@@ -62,7 +62,12 @@ public class EggsTest {
         player.setTurnsUntilLayEggs(0);
         g.layEggs();
         EggCluster egg = map.getEggs(g.getPlayerX(), g.getPlayerY()).get(0);
-        double expected = player.getHatchlingWeight() * 1.0;
+        DinosaurStats base = StatsLoader.getDinoStats().get("Allosaurus");
+        double hatch = base.getHatchlingWeight();
+        if (hatch <= 0) {
+            hatch = Math.max(1.0, base.getAdultWeight() * 0.001);
+        }
+        double expected = hatch * base.getNumEggs();
         Assertions.assertEquals(expected, egg.getWeight(), 1e-9);
     }
 }


### PR DESCRIPTION
## Summary
- pull player egg-laying stats from `StatsLoader`
- expose egg-related fields on `DinosaurStats`
- update tests for the new egg logic

## Testing
- `mvn -f java/pom.xml test` *(fails: Tests run: 54, Failures: 1)*

------
https://chatgpt.com/codex/tasks/task_e_686c0226ea00832e84bf1501f186c140