### PR TITLE
Fix Hell Creek burrow spawning

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -86,6 +86,10 @@ public class Game {
                 mammalSpecies.add(entry.getKey());
             }
         }
+        if (mammalSpecies.isEmpty() && "Hell Creek".equals(formation)
+                && StatsLoader.getCritterStats().containsKey("Didelphodon")) {
+            mammalSpecies.add("Didelphodon");
+        }
 
         // choose player dinosaur
         if (!StatsLoader.getDinoStats().isEmpty()) {

--- a/java/src/test/java/com/dinosurvival/game/DiggerTest.java
+++ b/java/src/test/java/com/dinosurvival/game/DiggerTest.java
@@ -30,6 +30,14 @@ public class DiggerTest {
         Assertions.assertNotNull(b);
         Assertions.assertFalse(b.isFull());
         Assertions.assertEquals(0.0, b.getProgress());
+        boolean found = false;
+        for (NPCAnimal a : map.getAnimals(x, y)) {
+            if ("Didelphodon".equals(a.getName())) {
+                found = true;
+                break;
+            }
+        }
+        Assertions.assertTrue(found);
     }
 
     @Test
@@ -58,6 +66,14 @@ public class DiggerTest {
         Burrow b = map.getBurrow(x, y);
         Assertions.assertNotNull(b);
         Assertions.assertFalse(b.isFull());
+        boolean found = false;
+        for (NPCAnimal a : map.getAnimals(x, y)) {
+            if (a != npc && "Didelphodon".equals(a.getName())) {
+                found = true;
+                break;
+            }
+        }
+        Assertions.assertTrue(found);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add fallback when mammal list is empty so digging produces Didelphodon
- check Didelphodon appears after digging a burrow in Java tests

## Testing
- `pytest -q`
- `mvn -f java/pom.xml -DskipTests=false test`

------
https://chatgpt.com/codex/tasks/task_e_686c02f2d0bc832e9608fe0b71ab0a81