### PR TITLE
Add Settings constants for Java

### DIFF
--- a/java/src/main/java/com/dinosurvival/game/Game.java
+++ b/java/src/main/java/com/dinosurvival/game/Game.java
@@ -9,6 +9,7 @@ import com.dinosurvival.game.Burrow;
 import com.dinosurvival.game.MapUtils;
 import com.dinosurvival.game.Setting;
 import com.dinosurvival.game.Terrain;
+import com.dinosurvival.game.Settings;
 import java.util.Iterator;
 import com.dinosurvival.util.StatsLoader;
 import java.io.IOException;
@@ -57,9 +58,7 @@ public class Game {
      * world without depending on the Python code.
      */
     public void start() {
-        Setting s = defaultSetting();
-        s.setFormation("Morrison");
-        start(s, null, new Random().nextLong());
+        start(Settings.MORRISON, null, new Random().nextLong());
     }
 
     /**
@@ -67,9 +66,7 @@ public class Game {
      * If {@code dinoName} is null the first available dinosaur is used.
      */
     public void start(String formation, String dinoName) {
-        Setting s = defaultSetting();
-        s.setFormation(formation);
-        start(s, dinoName, new Random().nextLong());
+        start(Settings.forFormation(formation), dinoName, new Random().nextLong());
     }
 
     /**
@@ -77,9 +74,7 @@ public class Game {
      * the provided random seed for map generation.
      */
     public void start(String formation, String dinoName, long seed) {
-        Setting s = defaultSetting();
-        s.setFormation(formation);
-        start(s, dinoName, seed);
+        start(Settings.forFormation(formation), dinoName, seed);
     }
 
     /**
@@ -206,36 +201,7 @@ public class Game {
      * {@link Map} when no configuration is provided.
      */
     private static Setting defaultSetting() {
-        Setting s = new Setting();
-        java.util.Map<String, Terrain> terrains = new java.util.HashMap<>();
-        terrains.put("desert", Terrain.DESERT);
-        terrains.put("plains", Terrain.PLAINS);
-        terrains.put("woodlands", Terrain.WOODLANDS);
-        terrains.put("forest", Terrain.FOREST);
-        terrains.put("highland_forest", Terrain.HIGHLAND_FOREST);
-        terrains.put("swamp", Terrain.SWAMP);
-        terrains.put("lake", Terrain.LAKE);
-        terrains.put("mountain", Terrain.MOUNTAIN);
-        terrains.put("volcano", Terrain.VOLCANO);
-        terrains.put("volcano_erupting", Terrain.VOLCANO_ERUPTING);
-        terrains.put("lava", Terrain.LAVA);
-        terrains.put("solidified_lava_field", Terrain.SOLIDIFIED_LAVA_FIELD);
-        s.setTerrains(terrains);
-
-        java.util.Map<String, Double> heights = new java.util.HashMap<>();
-        heights.put("low", 0.3);
-        heights.put("normal", 0.4);
-        heights.put("hilly", 0.2);
-        heights.put("mountain", 0.1);
-        s.setHeightLevels(heights);
-
-        java.util.Map<String, Double> humidity = new java.util.HashMap<>();
-        humidity.put("arid", 0.35);
-        humidity.put("normal", 0.4);
-        humidity.put("humid", 0.25);
-        s.setHumidityLevels(humidity);
-        s.setNumBurrows(5);
-        return s;
+        return Settings.MORRISON;
     }
 
     /**

--- a/java/src/main/java/com/dinosurvival/game/Map.java
+++ b/java/src/main/java/com/dinosurvival/game/Map.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
+import com.dinosurvival.game.Settings;
 
 /**
  * Rough Java port of the Python {@code Map} class. The implementation focuses
@@ -82,35 +83,7 @@ public class Map {
     }
 
     private static Setting defaultSetting() {
-        Setting s = new Setting();
-        java.util.Map<String, Terrain> terrains = new HashMap<>();
-        terrains.put("desert", Terrain.DESERT);
-        terrains.put("plains", Terrain.PLAINS);
-        terrains.put("woodlands", Terrain.WOODLANDS);
-        terrains.put("forest", Terrain.FOREST);
-        terrains.put("highland_forest", Terrain.HIGHLAND_FOREST);
-        terrains.put("swamp", Terrain.SWAMP);
-        terrains.put("lake", Terrain.LAKE);
-        terrains.put("mountain", Terrain.MOUNTAIN);
-        terrains.put("volcano", Terrain.VOLCANO);
-        terrains.put("volcano_erupting", Terrain.VOLCANO_ERUPTING);
-        terrains.put("lava", Terrain.LAVA);
-        terrains.put("solidified_lava_field", Terrain.SOLIDIFIED_LAVA_FIELD);
-        s.setTerrains(terrains);
-
-        java.util.Map<String, Double> heights = new HashMap<>();
-        heights.put("low", 0.3);
-        heights.put("normal", 0.4);
-        heights.put("hilly", 0.2);
-        heights.put("mountain", 0.1);
-        s.setHeightLevels(heights);
-
-        java.util.Map<String, Double> humidity = new HashMap<>();
-        humidity.put("arid", 0.35);
-        humidity.put("normal", 0.4);
-        humidity.put("humid", 0.25);
-        s.setHumidityLevels(humidity);
-        return s;
+        return Settings.MORRISON;
     }
 
     private void generate(java.util.Map<String, Terrain> terrains,

--- a/java/src/main/java/com/dinosurvival/game/Settings.java
+++ b/java/src/main/java/com/dinosurvival/game/Settings.java
@@ -1,0 +1,208 @@
+package com.dinosurvival.game;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Java equivalent of the Python settings module. Provides pre-defined
+ * {@link Setting} instances for each geologic formation.
+ */
+public final class Settings {
+
+    /** Configuration for the Morrison Formation. */
+    public static final Setting MORRISON;
+    /** Configuration for the Hell Creek formation. */
+    public static final Setting HELL_CREEK;
+
+    static {
+        MORRISON = buildMorrison();
+        HELL_CREEK = buildHellCreek();
+    }
+
+    private Settings() {
+        // utility class
+    }
+
+    /**
+     * Return the {@link Setting} for the given formation name. Defaults to
+     * {@link #MORRISON} if the name is unknown.
+     */
+    public static Setting forFormation(String formation) {
+        if (formation == null) {
+            return MORRISON;
+        }
+        String f = formation.trim().toLowerCase();
+        if (f.equals("hell creek")) {
+            return HELL_CREEK;
+        }
+        if (f.equals("morrison") || f.equals("morrison formation")) {
+            return MORRISON;
+        }
+        return MORRISON;
+    }
+
+    private static Setting buildMorrison() {
+        Map<String, Map<String, Object>> dinos = Map.of(
+            "Allosaurus", Map.of("energy_threshold", 0, "growth_stages", 3),
+            "Ceratosaurus", Map.of("energy_threshold", 0, "growth_stages", 3),
+            "Torvosaurus", Map.of("energy_threshold", 0, "growth_stages", 3),
+            "Ornitholestes", Map.of("energy_threshold", 0, "growth_stages", 3)
+        );
+
+        Map<String, Terrain> terrains = Map.ofEntries(
+            Map.entry("desert", Terrain.DESERT),
+            Map.entry("desert_flooded", Terrain.DESERT_FLOODED),
+            Map.entry("toxic_badlands", Terrain.TOXIC_BADLANDS),
+            Map.entry("plains", Terrain.PLAINS),
+            Map.entry("plains_flooded", Terrain.PLAINS_FLOODED),
+            Map.entry("woodlands", Terrain.WOODLANDS),
+            Map.entry("woodlands_flooded", Terrain.WOODLANDS_FLOODED),
+            Map.entry("forest", Terrain.FOREST),
+            Map.entry("forest_flooded", Terrain.FOREST_FLOODED),
+            Map.entry("forest_fire", Terrain.FOREST_FIRE),
+            Map.entry("forest_burnt", Terrain.FOREST_BURNT),
+            Map.entry("highland_forest", Terrain.HIGHLAND_FOREST),
+            Map.entry("highland_forest_fire", Terrain.HIGHLAND_FOREST_FIRE),
+            Map.entry("highland_forest_burnt", Terrain.HIGHLAND_FOREST_BURNT),
+            Map.entry("swamp", Terrain.SWAMP),
+            Map.entry("swamp_flooded", Terrain.SWAMP_FLOODED),
+            Map.entry("lake", Terrain.LAKE),
+            Map.entry("mountain", Terrain.MOUNTAIN),
+            Map.entry("volcano", Terrain.VOLCANO),
+            Map.entry("volcano_erupting", Terrain.VOLCANO_ERUPTING),
+            Map.entry("lava", Terrain.LAVA),
+            Map.entry("solidified_lava_field", Terrain.SOLIDIFIED_LAVA_FIELD)
+        );
+
+        Map<String, String> images = Map.ofEntries(
+            Map.entry("desert", "desert.png"),
+            Map.entry("desert_flooded", "desert_flooded.png"),
+            Map.entry("toxic_badlands", "badlands.png"),
+            Map.entry("plains", "plains.png"),
+            Map.entry("plains_flooded", "plains_flooded.png"),
+            Map.entry("woodlands", "woodlands.png"),
+            Map.entry("woodlands_flooded", "woodlands_flooded.png"),
+            Map.entry("forest", "forest.png"),
+            Map.entry("forest_flooded", "forest_flooded.png"),
+            Map.entry("forest_fire", "forest_fire.png"),
+            Map.entry("forest_burnt", "forest_burnt.png"),
+            Map.entry("highland_forest", "highland_forest.png"),
+            Map.entry("highland_forest_fire", "highland_forest_fire.png"),
+            Map.entry("highland_forest_burnt", "highland_forest_burnt.png"),
+            Map.entry("swamp", "swamp.png"),
+            Map.entry("swamp_flooded", "swamp_flooded.png"),
+            Map.entry("lake", "lake.png"),
+            Map.entry("mountain", "mountain.png"),
+            Map.entry("volcano", "volcano.png"),
+            Map.entry("volcano_erupting", "volcano_erupting.png"),
+            Map.entry("lava", "lava.png"),
+            Map.entry("solidified_lava_field", "solidified_lava_field.png")
+        );
+
+        Map<String, Double> heights = Map.of(
+            "low", 0.3,
+            "normal", 0.4,
+            "hilly", 0.2,
+            "mountain", 0.1
+        );
+
+        Map<String, Double> humidity = Map.of(
+            "arid", 0.35,
+            "normal", 0.4,
+            "humid", 0.25
+        );
+
+        return new Setting(
+            "Morrison Formation",
+            "Morrison",
+            new HashMap<>(dinos),
+            new HashMap<>(terrains),
+            new HashMap<>(images),
+            new HashMap<>(heights),
+            new HashMap<>(humidity),
+            0
+        );
+    }
+
+    private static Setting buildHellCreek() {
+        Map<String, Map<String, Object>> dinos = Map.of(
+            "Tyrannosaurus", Map.of("energy_threshold", 0, "growth_stages", 4),
+            "Acheroraptor", Map.of("energy_threshold", 0, "growth_stages", 3),
+            "Pectinodon", Map.of("energy_threshold", 0, "growth_stages", 3)
+        );
+
+        Map<String, Terrain> terrains = Map.ofEntries(
+            Map.entry("desert", Terrain.DESERT),
+            Map.entry("desert_flooded", Terrain.DESERT_FLOODED),
+            Map.entry("toxic_badlands", Terrain.TOXIC_BADLANDS),
+            Map.entry("plains", Terrain.PLAINS),
+            Map.entry("plains_flooded", Terrain.PLAINS_FLOODED),
+            Map.entry("woodlands", Terrain.WOODLANDS),
+            Map.entry("woodlands_flooded", Terrain.WOODLANDS_FLOODED),
+            Map.entry("forest", Terrain.FOREST),
+            Map.entry("forest_flooded", Terrain.FOREST_FLOODED),
+            Map.entry("forest_fire", Terrain.FOREST_FIRE),
+            Map.entry("forest_burnt", Terrain.FOREST_BURNT),
+            Map.entry("highland_forest", Terrain.HIGHLAND_FOREST),
+            Map.entry("highland_forest_fire", Terrain.HIGHLAND_FOREST_FIRE),
+            Map.entry("highland_forest_burnt", Terrain.HIGHLAND_FOREST_BURNT),
+            Map.entry("swamp", Terrain.SWAMP),
+            Map.entry("swamp_flooded", Terrain.SWAMP_FLOODED),
+            Map.entry("lake", Terrain.LAKE),
+            Map.entry("mountain", Terrain.MOUNTAIN),
+            Map.entry("volcano", Terrain.VOLCANO),
+            Map.entry("volcano_erupting", Terrain.VOLCANO_ERUPTING),
+            Map.entry("lava", Terrain.LAVA),
+            Map.entry("solidified_lava_field", Terrain.SOLIDIFIED_LAVA_FIELD)
+        );
+
+        Map<String, String> images = Map.ofEntries(
+            Map.entry("desert", "desert.png"),
+            Map.entry("desert_flooded", "desert_flooded.png"),
+            Map.entry("toxic_badlands", "badlands.png"),
+            Map.entry("plains", "plains.png"),
+            Map.entry("plains_flooded", "plains_flooded.png"),
+            Map.entry("woodlands", "woodlands.png"),
+            Map.entry("woodlands_flooded", "woodlands_flooded.png"),
+            Map.entry("forest", "forest.png"),
+            Map.entry("forest_flooded", "forest_flooded.png"),
+            Map.entry("forest_fire", "forest_fire.png"),
+            Map.entry("forest_burnt", "forest_burnt.png"),
+            Map.entry("highland_forest", "highland_forest.png"),
+            Map.entry("highland_forest_fire", "highland_forest_fire.png"),
+            Map.entry("highland_forest_burnt", "highland_forest_burnt.png"),
+            Map.entry("swamp", "swamp.png"),
+            Map.entry("swamp_flooded", "swamp_flooded.png"),
+            Map.entry("lake", "lake.png"),
+            Map.entry("mountain", "mountain.png"),
+            Map.entry("volcano", "volcano.png"),
+            Map.entry("volcano_erupting", "volcano_erupting.png"),
+            Map.entry("lava", "lava.png"),
+            Map.entry("solidified_lava_field", "solidified_lava_field.png")
+        );
+
+        Map<String, Double> heights = Map.of(
+            "low", 0.3,
+            "normal", 0.45,
+            "hilly", 0.15,
+            "mountain", 0.1
+        );
+
+        Map<String, Double> humidity = Map.of(
+            "arid", 0.2,
+            "normal", 0.5,
+            "humid", 0.3
+        );
+
+        return new Setting(
+            "Hell Creek",
+            "Hell Creek",
+            new HashMap<>(dinos),
+            new HashMap<>(terrains),
+            new HashMap<>(images),
+            new HashMap<>(heights),
+            new HashMap<>(humidity),
+            5
+        );
+    }
+}

--- a/java/src/main/java/com/dinosurvival/ui/SetupDialog.java
+++ b/java/src/main/java/com/dinosurvival/ui/SetupDialog.java
@@ -1,7 +1,7 @@
 package com.dinosurvival.ui;
 
 import com.dinosurvival.util.StatsLoader;
-import java.util.Map;
+import com.dinosurvival.game.Settings;
 import java.awt.BorderLayout;
 import java.awt.GridLayout;
 import java.io.IOException;
@@ -14,12 +14,6 @@ public class SetupDialog extends JDialog {
     private String dinosaur;
     private final JComboBox<String> formationBox = new JComboBox<>(new String[]{"Morrison", "Hell Creek"});
     private final JComboBox<String> dinoBox = new JComboBox<>();
-    private static final Map<String, String[]> PLAYABLE_DINOS = Map.of(
-            "Morrison",
-            new String[]{"Allosaurus", "Ceratosaurus", "Torvosaurus", "Ornitholestes"},
-            "Hell Creek",
-            new String[]{"Tyrannosaurus", "Acheroraptor", "Pectinodon"}
-    );
 
     public SetupDialog(JFrame parent) {
         super(parent, "New Game", true);
@@ -50,7 +44,8 @@ public class SetupDialog extends JDialog {
         } catch (IOException ex) {
             // ignore
         }
-        String[] dinos = PLAYABLE_DINOS.getOrDefault(sel, new String[0]);
+        String[] dinos = Settings.forFormation(sel)
+                .getPlayableDinos().keySet().toArray(new String[0]);
         DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>(dinos);
         dinoBox.setModel(model);
         if (model.getSize() > 0) {

--- a/java/src/test/java/com/dinosurvival/game/DiggerTest.java
+++ b/java/src/test/java/com/dinosurvival/game/DiggerTest.java
@@ -5,8 +5,7 @@ import com.dinosurvival.game.Map;
 import com.dinosurvival.game.Burrow;
 import com.dinosurvival.model.NPCAnimal;
 import com.dinosurvival.util.StatsLoader;
-import com.dinosurvival.ui.SetupDialog;
-import java.lang.reflect.Field;
+import com.dinosurvival.game.Settings;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -77,13 +76,9 @@ public class DiggerTest {
     }
 
     @Test
-    public void testHellCreekPlayableList() throws Exception {
-        Field f = SetupDialog.class.getDeclaredField("PLAYABLE_DINOS");
-        f.setAccessible(true);
-        @SuppressWarnings("unchecked")
-        java.util.Map<String, String[]> map =
-                (java.util.Map<String, String[]>) f.get(null);
-        String[] list = map.get("Hell Creek");
+    public void testHellCreekPlayableList() {
+        String[] list = Settings.HELL_CREEK.getPlayableDinos()
+                .keySet().toArray(new String[0]);
         Assertions.assertNotNull(list);
         Assertions.assertTrue(Arrays.asList(list).contains("Pectinodon"));
         Assertions.assertTrue(Arrays.asList(list).contains("Acheroraptor"));


### PR DESCRIPTION
## Summary
- implement `Settings` with `MORRISON` and `HELL_CREEK`
- load available dinosaurs from `Settings` in `SetupDialog`
- use new settings when starting `Game` and generating `Map`
- update tests to reference the new configuration

## Testing
- `mvn -f java/pom.xml test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c0da18cb0832e98b0282a8be96c9c