### PR TITLE
Fix deterministic hunts

### DIFF
--- a/java/src/test/java/com/dinosurvival/game/CombatTest.java
+++ b/java/src/test/java/com/dinosurvival/game/CombatTest.java
@@ -10,9 +10,9 @@ public class CombatTest {
 
     @Test
     public void test_player_attack_damage() throws Exception {
-        StatsLoader.load(Path.of("..", "dinosurvival"), "Morrison");
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
         Game game = new Game();
-        game.start("Morrison", "Allosaurus");
+        game.start("Hell Creek", "Tyrannosaurus");
         Map map = game.getMap();
         for (int ty = 0; ty < map.getHeight(); ty++) {
             for (int tx = 0; tx < map.getWidth(); tx++) {
@@ -21,7 +21,7 @@ public class CombatTest {
         }
         NPCAnimal npc = new NPCAnimal();
         npc.setId(1);
-        npc.setName("Stegosaurus");
+        npc.setName("Centipede");
         npc.setWeight(1.0);
         map.addAnimal(game.getPlayerX(), game.getPlayerY(), npc);
         game.huntNpc(npc.getId());

--- a/java/src/test/java/com/dinosurvival/game/HuntsTest.java
+++ b/java/src/test/java/com/dinosurvival/game/HuntsTest.java
@@ -10,9 +10,9 @@ public class HuntsTest {
 
     @Test
     public void testLiveHuntCountsKill() throws Exception {
-        StatsLoader.load(Path.of("..", "dinosurvival"), "Morrison");
+        StatsLoader.load(Path.of("..", "dinosurvival"), "Hell Creek");
         Game game = new Game();
-        game.start("Morrison", "Allosaurus", 0L);
+        game.start("Hell Creek", "Tyrannosaurus", 0L);
         Map map = game.getMap();
         for (int ty = 0; ty < map.getHeight(); ty++) {
             for (int tx = 0; tx < map.getWidth(); tx++) {
@@ -21,11 +21,11 @@ public class HuntsTest {
         }
         NPCAnimal npc = new NPCAnimal();
         npc.setId(1);
-        npc.setName("Stegosaurus");
+        npc.setName("Centipede");
         npc.setWeight(1.0);
         map.addAnimal(game.getPlayerX(), game.getPlayerY(), npc);
         game.huntNpc(npc.getId());
-        Assertions.assertEquals(1, game.getHuntStats().get("Stegosaurus")[1]);
+        Assertions.assertEquals(1, game.getHuntStats().get("Centipede")[1]);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- revert forced hunt catch logic
- use Tyrannosaurus vs Centipede in hunting-related tests for reliability

## Testing
- `mvn test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c0bfb1ed8832e9b954ec6a88fc7d2