### PR TITLE
Refactor NPC growth helpers into controller

### DIFF
--- a/src/main/java/com/dinosurvival/game/NpcController.java
+++ b/src/main/java/com/dinosurvival/game/NpcController.java
@@ -17,6 +17,7 @@ public class NpcController {
     private Weather weather;
     private int nextNpcId = 1;
     private final List<NPCAnimal> spawned = new ArrayList<>();
+    private final List<String> mammalSpecies = new ArrayList<>();
 
     public NpcController(Map map, Weather weather) {
         this.map = map;
@@ -37,6 +38,24 @@ public class NpcController {
 
     public void trackSpawn(NPCAnimal npc) {
         spawned.add(npc);
+    }
+
+    public void initMammalSpecies(String formation) {
+        mammalSpecies.clear();
+        for (var entry : StatsLoader.getCritterStats().entrySet()) {
+            Object cls = entry.getValue().get("class");
+            if (cls != null && cls.toString().equals("mammal")) {
+                mammalSpecies.add(entry.getKey());
+            }
+        }
+        if (mammalSpecies.isEmpty() && "Hell Creek".equals(formation)
+                && StatsLoader.getCritterStats().containsKey("Didelphodon")) {
+            mammalSpecies.add("Didelphodon");
+        }
+    }
+
+    public List<String> getMammalSpecies() {
+        return mammalSpecies;
     }
 
     public List<NPCAnimal> getSpawned() {
@@ -414,16 +433,9 @@ public class NpcController {
         b.setFull(false);
         b.setProgress(0.0);
 
-        List<String> mammals = new ArrayList<>();
-        for (var entry : StatsLoader.getCritterStats().entrySet()) {
-            Object cls = entry.getValue().get("class");
-            if (cls != null && cls.toString().equals("mammal")) {
-                mammals.add(entry.getKey());
-            }
-        }
-        if (!mammals.isEmpty()) {
+        if (!mammalSpecies.isEmpty()) {
             Random r = new Random();
-            String name = mammals.get(r.nextInt(mammals.size()));
+            String name = mammalSpecies.get(r.nextInt(mammalSpecies.size()));
             java.util.Map<String, Object> stats = StatsLoader.getCritterStats().get(name);
             double weight = 0.0;
             Object wObj = stats.get("adult_weight");

--- a/src/test/java/com/dinosurvival/CarcassBehaviorTest.java
+++ b/src/test/java/com/dinosurvival/CarcassBehaviorTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 public class CarcassBehaviorTest {
     @BeforeAll
     public static void loadStats() throws Exception {
-        Path base = Path.of("..", "conf");
+        Path base = Path.of("conf");
         StatsLoader.load(base, "Morrison");
     }
 

--- a/src/test/java/com/dinosurvival/EggsTest.java
+++ b/src/test/java/com/dinosurvival/EggsTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 public class EggsTest {
     @BeforeAll
     public static void loadStats() throws Exception {
-        Path base = Path.of("..", "conf");
+        Path base = Path.of("conf");
         StatsLoader.load(base, "Morrison");
     }
 

--- a/src/test/java/com/dinosurvival/StatsLoaderTest.java
+++ b/src/test/java/com/dinosurvival/StatsLoaderTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 public class StatsLoaderTest {
     @Test
     public void testLoadStats() throws Exception {
-        Path base = Path.of("..", "conf");
+        Path base = Path.of("conf");
         StatsLoader.load(base, "Morrison");
         DinosaurStats allo = StatsLoader.getDinoStats().get("Allosaurus");
         Assertions.assertNotNull(allo);

--- a/src/test/java/com/dinosurvival/game/BoneBreakTest.java
+++ b/src/test/java/com/dinosurvival/game/BoneBreakTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 public class BoneBreakTest {
     @Test
     public void testPlayerBreaksBonesTarget() throws Exception {
-        StatsLoader.load(Path.of("..", "conf"), "Hell Creek");
+        StatsLoader.load(Path.of("conf"), "Hell Creek");
         Game g = new Game();
         g.start("Hell Creek", "Acheroraptor");
         Map map = g.getMap();


### PR DESCRIPTION
## Summary
- move NPC consumption and growth helpers from `Game` to `NpcController`
- let `NpcController` maintain mammal species list
- initialise mammal list in game start
- reference controller mammal list from player dig logic
- update tests to load stats from project `conf` directory

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_686cece4ed90832eb2b55d6cdce44c1e