### PR TITLE
Add exec plugin for simpler launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The jar produced by the build does not bundle its dependencies. Run the
 application with Maven so that they are included on the classpath:
 
 ```bash
-mvn exec:java -Dexec.mainClass=com.dinosurvival.ui.Main
+mvn exec:java
 ```
 
 Running the game opens a menu with buttons for the available

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,14 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.dinosurvival.ui.Main</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.3</version>


### PR DESCRIPTION
## Summary
- set main class for `exec:java` in the Maven build
- document that the game can be run with `mvn exec:java`

## Testing
- `mvn -e test`

------
https://chatgpt.com/codex/tasks/task_e_686ea42c623c832e86250bbe03fa73f9