### PR TITLE
Add weather-driven forest fire mechanics

### DIFF
--- a/src/main/java/com/dinosurvival/game/Game.java
+++ b/src/main/java/com/dinosurvival/game/Game.java
@@ -561,7 +561,7 @@ public class Game {
 
         turnMessages.addAll(map.updateVolcanicActivity(x, y, playerManager.getPlayer()));
         turnMessages.addAll(map.updateFlood(x, y, playerManager.getPlayer(), weather.getFloodChance()));
-        turnMessages.addAll(map.updateForestFire());
+        turnMessages.addAll(map.updateForestFire(weather));
         updateEggs();
         map.growPlants(StatsLoader.getPlantStats());
         npcController.spawnCritters(false);


### PR DESCRIPTION
## Summary
- make `updateForestFire` accept the current `Weather`
- let heatwaves ignite random forest fires
- vary fire spread rate depending on weather
- update `Game` to pass weather to `updateForestFire`

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_686eb4eeec88832eb69413d27476e208