### PR TITLE
Fix flaky hunt damage test

### DIFF
--- a/src/main/java/com/dinosurvival/game/Game.java
+++ b/src/main/java/com/dinosurvival/game/Game.java
@@ -26,6 +26,7 @@ public class Game {
     private Weather weather;
     private int weatherTurns;
     private final Random weatherRng = new Random(1);
+    private Random rng = new Random();
     private NpcController npcController;
     private boolean won;
     private int turn;
@@ -87,6 +88,7 @@ public class Game {
             throw new RuntimeException(e);
         }
 
+        rng = new Random(seed);
         worldStats = new WorldStats();
         worldStats.initSpecies(StatsLoader.getDinoStats().keySet());
         worldStats.initSpecies(StatsLoader.getCritterStats().keySet());
@@ -668,7 +670,7 @@ public class Game {
             double targetSpeed = npcEffectiveSpeed(target, stats);
             double relSpeed = targetSpeed / Math.max(playerSpeed, 0.1);
             double catchChance = calculateCatchChance(relSpeed);
-            if (Math.random() > catchChance) {
+            if (rng.nextDouble() > catchChance) {
                 turnMessages.add("The " + npcLabel(target) + " escaped before you could catch it.");
                 applyTurnCosts(false, 5.0);
                 checkVictory();

--- a/src/test/java/com/dinosurvival/game/DamageMessageTest.java
+++ b/src/test/java/com/dinosurvival/game/DamageMessageTest.java
@@ -11,7 +11,7 @@ public class DamageMessageTest {
     public void testHuntOnlyOneDamageMessage() throws Exception {
         StatsLoader.load(Path.of("conf"), "Hell Creek");
         Game game = new Game();
-        game.start("Hell Creek", "Tyrannosaurus");
+        game.start("Hell Creek", "Tyrannosaurus", 0L);
         Map map = game.getMap();
         for (int y = 0; y < map.getHeight(); y++) {
             for (int x = 0; x < map.getWidth(); x++) {


### PR DESCRIPTION
## Summary
- seed the game RNG for deterministic hunt behaviour
- use the seeded RNG when attempting to catch prey
- supply a fixed seed in `DamageMessageTest`

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_686ee62a0444832e8b2fed3dab14fd7c